### PR TITLE
fix: limit push builds to task/ directory changes

### DIFF
--- a/.tekton/coverity-availability-check-v02-push.yaml
+++ b/.tekton/coverity-availability-check-v02-push.yaml
@@ -8,8 +8,7 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "main" && ( "task/coverity-availability-check/0.2/***".pathChanged() || ".tekton/coverity-availability-check-v02-pull-request.yaml".pathChanged()
-      )
+      == "main" && "/task/coverity-availability-check/0.2/***".pathChanged()
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: konflux-sast-tasks

--- a/.tekton/sast-shell-check-v01-push.yaml
+++ b/.tekton/sast-shell-check-v01-push.yaml
@@ -8,8 +8,7 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "main" && ( "task/sast-shell-check/0.1/***".pathChanged() || ".tekton/sast-shell-check-v01-pull-request.yaml".pathChanged()
-      )
+      == "main" && "/task/sast-shell-check/0.1/***".pathChanged()
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: konflux-sast-tasks

--- a/.tekton/sast-snyk-check-v04-push.yaml
+++ b/.tekton/sast-snyk-check-v04-push.yaml
@@ -8,8 +8,7 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "main" && ( "task/sast-snyk-check/0.4/***".pathChanged() || ".tekton/sast-snyk-check-v04-pull-request.yaml".pathChanged()
-      )
+      == "main" && "/task/sast-snyk-check/0.4/***".pathChanged()
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: konflux-sast-tasks

--- a/.tekton/sast-unicode-check-v03-push.yaml
+++ b/.tekton/sast-unicode-check-v03-push.yaml
@@ -8,8 +8,7 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "main" && ( "task/sast-unicode-check/0.3/***".pathChanged() || ".tekton/sast-unicode-check-v03-pull-request.yaml".pathChanged()
-      )
+      == "main" && "/task/sast-unicode-check/0.3/***".pathChanged()
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: konflux-sast-tasks


### PR DESCRIPTION
Limit the push pipeline runs to changes on the task files to avoid unnecessary noise republishing the same task over and over again

# Before you complete this pull request ...

Look for any open pull requests in the repository with the title "e2e-tests update" and 
see if there are recent e2e-tests updates that will be applicable to your change.
