### PR TITLE
fix(KONFLUX-9326) add param to enable specific folders scanning

### DIFF
--- a/task-generator/trusted-artifacts/golden/sast-snyk-check/base.yaml
+++ b/task-generator/trusted-artifacts/golden/sast-snyk-check/base.yaml
@@ -21,6 +21,10 @@ spec:
       type: string
       description: Append arguments.
       default: "--all-projects --exclude=test*,vendor,deps"
+    - name: TARGET_DIRS
+      description: Target directories in component's source code. Multiple values should be separated with commas.
+      type: string
+      default: "."
   volumes:
     - name: snyk-secret
       secret:
@@ -41,6 +45,8 @@ spec:
           value: $(params.SNYK_SECRET)
         - name: ARGS
           value: $(params.ARGS)
+        - name: TARGET_DIRS
+          value: $(params.TARGET_DIRS)
       script: |
         #!/usr/bin/env bash
         set -euo pipefail
@@ -63,7 +69,28 @@ spec:
 
         SNYK_EXIT_CODE=0
         SOURCE_CODE_DIR=$(workspaces.workspace.path)/source
-        snyk code test $ARGS "$SOURCE_CODE_DIR" --max-depth=1 --sarif-file-output=sast_snyk_check_out.json 1>&2>> stdout.txt || SNYK_EXIT_CODE=$?
+        # Generate full paths for each directory in TARGET_DIRS
+        IFS="," read -ra TARGETS_ARRAY <<< "$TARGET_DIRS"
+        for d in "${TARGETS_ARRAY[@]}"; do
+          potential_path="${SOURCE_CODE_DIR}/${d}"
+          resolved_path=$(realpath -m "$potential_path")
+          # Ensure resolved path is still within SOURCE_CODE_DIR
+          if [[ ! "$resolved_path" == "$SOURCE_CODE_DIR"* ]]; then
+            echo "Error: path traversal attempt, '$potential_path' is outside '$SOURCE_CODE_DIR'"
+            exit 1
+          fi
+          # Ensure directory exists
+          if [ ! -d "$resolved_path" ]; then
+            echo "Warning: Directory $resolved_path does not exist, skipping"
+            continue
+          fi
+          echo "INFO: Scanning directory: $resolved_path"
+          snyk code test $ARGS "$resolved_path" --max-depth=1 --sarif-file-output="${resolved_path}/sast_snyk_check_out_${d//\//_}.json" 1>&2>> stdout.txt || true
+        done
+        # Merge all SARIF outputs
+        find "$SOURCE_CODE_DIR" -name "sast_snyk_check_out_*.json" -exec cat {} + > sast_snyk_check_out.json
+        SNYK_EXIT_CODE=$?
+        set -e
         test_not_skipped=0
         SKIP_MSG="We found 0 supported files"
         grep -q "$SKIP_MSG" stdout.txt || test_not_skipped=$?

--- a/task-generator/trusted-artifacts/golden/sast-snyk-check/ta.yaml
+++ b/task-generator/trusted-artifacts/golden/sast-snyk-check/ta.yaml
@@ -44,6 +44,10 @@ spec:
       type: string
       description: Append arguments.
       default: "--all-projects --exclude=test*,vendor,deps"
+    - name: TARGET_DIRS
+      description: Target directories in component's source code. Multiple values should be separated with commas.
+      type: string
+      default: "."
   volumes:
     - name: snyk-secret
       secret:
@@ -74,6 +78,8 @@ spec:
           value: $(params.SNYK_SECRET)
         - name: ARGS
           value: $(params.ARGS)
+        - name: TARGET_DIRS
+          value: $(params.TARGET_DIRS)
       script: |
         #!/usr/bin/env bash
         set -euo pipefail
@@ -96,7 +102,28 @@ spec:
 
         SNYK_EXIT_CODE=0
         SOURCE_CODE_DIR=/var/workdir/source
-        snyk code test $ARGS "$SOURCE_CODE_DIR" --max-depth=1 --sarif-file-output=sast_snyk_check_out.json 1>&2>> stdout.txt || SNYK_EXIT_CODE=$?
+        # Generate full paths for each directory in TARGET_DIRS
+        IFS="," read -ra TARGETS_ARRAY <<< "$TARGET_DIRS"
+        for d in "${TARGETS_ARRAY[@]}"; do
+          potential_path="${SOURCE_CODE_DIR}/${d}"
+          resolved_path=$(realpath -m "$potential_path")
+          # Ensure resolved path is still within SOURCE_CODE_DIR
+          if [[ ! "$resolved_path" == "$SOURCE_CODE_DIR"* ]]; then
+            echo "Error: path traversal attempt, '$potential_path' is outside '$SOURCE_CODE_DIR'"
+            exit 1
+          fi
+          # Ensure directory exists
+          if [ ! -d "$resolved_path" ]; then
+            echo "Warning: Directory $resolved_path does not exist, skipping"
+            continue
+          fi
+          echo "INFO: Scanning directory: $resolved_path"
+          snyk code test $ARGS "$resolved_path" --max-depth=1 --sarif-file-output="${resolved_path}/sast_snyk_check_out_${d//\//_}.json" 1>&2>> stdout.txt || true
+        done
+        # Merge all SARIF outputs
+        find "$SOURCE_CODE_DIR" -name "sast_snyk_check_out_*.json" -exec cat {} + > sast_snyk_check_out.json
+        SNYK_EXIT_CODE=$?
+        set -e
         test_not_skipped=0
         SKIP_MSG="We found 0 supported files"
         grep -q "$SKIP_MSG" stdout.txt || test_not_skipped=$?

--- a/task/sast-snyk-check/0.4/README.md
+++ b/task/sast-snyk-check/0.4/README.md
@@ -18,6 +18,7 @@ Snyk's SAST tool uses a combination of static analysis and machine learning tech
 | IMP_FINDINGS_ONLY  | Report only important findings.  To report all findings, specify "false"                                                                         | true          | true     |
 | KFP_GIT_URL        | Known False Positives (KFP) git URL (optionally taking a revision delimited by \#). Defaults to "SITE_DEFAULT", which means the default value "https://gitlab.cee.redhat.com/osh/known-false-positives.git" for internal Konflux instance and empty string for external Konflux instance. If set to an empty string, the KFP filtering is disabled.|SITE_DEFAULT|false|
 | PROJECT_NAME       | Name of the scanned project, used to find path exclusions. By default, the Konflux component name will be used.                                  | ""            | false    |
+|TARGET_DIRS|Target directories in component's source code. Multiple values should be separated with commas.|.|false|
 | RECORD_EXCLUDED    | Write excluded records in file. Useful for auditing.                                                                                             | false         | false    |
 |image-digest|Digest of the image to scan.||true|
 |image-url|Image URL.||true|

--- a/task/sast-snyk-check/0.4/sast-snyk-check.yaml
+++ b/task/sast-snyk-check/0.4/sast-snyk-check.yaml
@@ -66,6 +66,10 @@ spec:
       type: string
       description: Directories or files to be excluded from Snyk scan (Comma-separated). Useful to split the directories of a git repo across multiple components.
       default: ""
+    - name: TARGET_DIRS
+      description: Target directories in component's source code. Multiple values should be separated with commas.
+      type: string
+      default: "."
   volumes:
     - name: snyk-secret
       secret:
@@ -120,6 +124,8 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.annotations['pipelinesascode.tekton.dev/log-url']
+        - name: TARGET_DIRS
+          value: $(params.TARGET_DIRS)
       script: |
         #!/usr/bin/env bash
 
@@ -172,7 +178,28 @@ spec:
         set +e
         # We do want to expand ARGS (it can be multiple CLI flags, not just one)
         # shellcheck disable=SC2086
-        snyk code test $ARGS --severity-threshold="$SEVERITY_THRESHOLD" "$SOURCE_CODE_DIR" --max-depth=1 --sarif-file-output="${SOURCE_CODE_DIR}"/sast_snyk_check_out.json 1>&2>> stdout.txt
+        # Generate full paths for each directory in TARGET_DIRS
+        IFS="," read -ra TARGETS_ARRAY <<< "$TARGET_DIRS"
+        for d in "${TARGETS_ARRAY[@]}"; do
+          potential_path="${SOURCE_CODE_DIR}/${d}"
+          resolved_path=$(realpath -m "$potential_path")
+          # Ensure resolved path is still within SOURCE_CODE_DIR
+          if [[ ! "$resolved_path" == "$SOURCE_CODE_DIR"* ]]; then
+            echo "Error: path traversal attempt, '$potential_path' is outside '$SOURCE_CODE_DIR'"
+            exit 1
+          fi
+          # Ensure directory exists
+          if [ ! -d "$resolved_path" ]; then
+            echo "Warning: Directory $resolved_path does not exist, skipping"
+            continue
+          fi
+          echo "INFO: Scanning directory: $resolved_path"
+          # We do want to expand ARGS (it can be multiple CLI flags, not just one)
+          # shellcheck disable=SC2086
+          snyk code test $ARGS --severity-threshold="$SEVERITY_THRESHOLD" "$resolved_path" --max-depth=1 --sarif-file-output="${resolved_path}/sast_snyk_check_out_${d//\//_}.json" 1>&2>> stdout.txt || true
+        done
+        # Merge all SARIF outputs
+        find "$SOURCE_CODE_DIR" -name "sast_snyk_check_out_*.json" -exec cat {} + > "${SOURCE_CODE_DIR}/sast_snyk_check_out.json"
         SNYK_EXIT_CODE=$?
         set -e
         test_not_skipped=0


### PR DESCRIPTION
This PR is the implementation of JIRA ticket [PSSECAUT-1226](https://issues.redhat.com//browse/PSSECAUT-1226) with proper TARGET_DIRS support for Snyk tasks, resolving the original memory issue reported in the bug thread!

For more information review [KONFLUX-9326](https://issues.redhat.com/browse/KONFLUX-9326)