### PR TITLE
Set desirable resource consumption limits for all steps of task:'sast-coverity-check'

### DIFF
--- a/task/sast-coverity-check-oci-ta/0.3/sast-coverity-check-oci-ta.yaml
+++ b/task/sast-coverity-check-oci-ta/0.3/sast-coverity-check-oci-ta.yaml
@@ -288,10 +288,10 @@ spec:
   stepTemplate:
     computeResources:
       limits:
-        memory: 4Gi
+        memory: 128Mi
       requests:
         cpu: "1"
-        memory: 1Gi
+        memory: 128Mi
     env:
       - name: ACTIVATION_KEY
         value: $(params.ACTIVATION_KEY)
@@ -350,9 +350,9 @@ spec:
     - name: use-trusted-artifact
       computeResources:
         limits:
-          memory: 5Gi
+          memory: 4Gi
         requests:
-          memory: 5Gi
+          memory: 4Gi
       image: quay.io/konflux-ci/build-trusted-artifacts:latest@sha256:aa601d847eafa87747894b770eff43b47cffe2cc39059bb345ee58b378473b8f
       args:
         - use
@@ -1220,7 +1220,7 @@ spec:
         fi
       computeResources:
         limits:
-          memory: 15Gi
+          memory: 9Gi
         requests:
           cpu: "4"
-          memory: 15Gi
+          memory: 9Gi

--- a/task/sast-coverity-check-oci-ta/0.3/sast-coverity-check-oci-ta.yaml
+++ b/task/sast-coverity-check-oci-ta/0.3/sast-coverity-check-oci-ta.yaml
@@ -348,6 +348,11 @@ spec:
         name: workdir
   steps:
     - name: use-trusted-artifact
+      computeResources:
+        limits:
+          memory: 5Gi
+        requests:
+          memory: 5Gi
       image: quay.io/konflux-ci/build-trusted-artifacts:latest@sha256:aa601d847eafa87747894b770eff43b47cffe2cc39059bb345ee58b378473b8f
       args:
         - use
@@ -1005,7 +1010,7 @@ spec:
           memory: 16Gi
         requests:
           cpu: "4"
-          memory: 4Gi
+          memory: 16Gi
       securityContext:
         capabilities:
           add:
@@ -1215,7 +1220,7 @@ spec:
         fi
       computeResources:
         limits:
-          memory: 16Gi
+          memory: 15Gi
         requests:
           cpu: "4"
-          memory: 4Gi
+          memory: 15Gi


### PR DESCRIPTION
As per '[https://issues.redhat.com/browse/KONFLUX-6712]' we are supposed to define resources for steps within a task in such a way that the resources those steps are actually consuming in real clusters can be guaranteed. This makes sure that resources needed by other core system services (as mentioned in '[https://issues.redhat.com/browse/OHSS-48388]') can be guaranteed too.

We generated **data for last 24 hours** from all available **conflux clusters** by extracting all **PODs** that were created from the task:"**sast-coverity-check**", and then we extracted the **max MEMORY** used by all the containers/steps in those PODs. Following are our observations:

- "**step-prepare**" is using a max of 11Mb, so it can keep using the resources defined in 'stepTemplate' as below:

```shell
  stepTemplate:
    computeResources:
      limits:
        memory: 4Gi
      requests:
        cpu: "1"
        memory: 1Gi
``` 

Memory Usage stats by "step-prepare":
```shell
"default/api-kflux-ocp-p01-7ayg-p1-openshiftapps-com:6443/smodak", "sast-coverity-check-oci-ta", "step-prepare", 0 Mb
"default/api-kflux-osp-p01-yt45-p1-openshiftapps-com:6443/smodak", "sast-coverity-check-oci-ta", "step-prepare", 0 Mb
"default/api-kflux-prd-es01-1ion-p1-openshiftapps-com:6443/smodak", "sast-coverity-check-oci-ta", "step-prepare", 0 Mb
"default/api-kflux-prd-rh02-0fk9-p1-openshiftapps-com:6443/smodak", "sast-coverity-check-oci-ta", "step-prepare", 10 Mb
"default/api-kflux-prd-rh03-nnv1-p1-openshiftapps-com:6443/smodak", "sast-coverity-check-oci-ta", "step-prepare", 1 Mb
"default/api-kflux-rhel-p01-fc38-p1-openshiftapps-com:6443/smodak", "sast-coverity-check-oci-ta", "step-prepare", 0 Mb
"default/api-kflux-stg-es01-21tc-p1-openshiftapps-com:6443/smodak", "sast-coverity-check-oci-ta", "step-prepare", 0 Mb
"default/api-stone-prd-rh01-pg1f-p1-openshiftapps-com:6443/smodak", "sast-coverity-check-oci-ta", "step-prepare", 9 Mb
"default/api-stone-prod-p02-hjvn-p1-openshiftapps-com:6443/smodak", "sast-coverity-check-oci-ta", "step-prepare", 11 Mb
"default/api-stone-stage-p01-hpmt-p1-openshiftapps-com:6443/smodak", "sast-coverity-check-oci-ta", "step-prepare", 0 Mb
"default/api-stone-stg-rh01-l2vh-p1-openshiftapps-com:6443/smodak", "sast-coverity-check-oci-ta", "step-prepare", 0 Mb
```

- "**step-use-trusted-artifact**" is using close to 5G, the resources defined in 'stepTemplate' is not sufficient. Hence we need to define for it. Memory Usage stats by "step-use-trusted-artifact":
```shell
"default/api-kflux-ocp-p01-7ayg-p1-openshiftapps-com:6443/smodak", "sast-coverity-check-oci-ta", "step-use-trusted-artifact", 0 Mb
"default/api-kflux-osp-p01-yt45-p1-openshiftapps-com:6443/smodak", "sast-coverity-check-oci-ta", "step-use-trusted-artifact", 0 Mb
"default/api-kflux-prd-es01-1ion-p1-openshiftapps-com:6443/smodak", "sast-coverity-check-oci-ta", "step-use-trusted-artifact", 0 Mb
"default/api-kflux-prd-rh02-0fk9-p1-openshiftapps-com:6443/smodak", "sast-coverity-check-oci-ta", "step-use-trusted-artifact", 1298 Mb
"default/api-kflux-prd-rh03-nnv1-p1-openshiftapps-com:6443/smodak", "sast-coverity-check-oci-ta", "step-use-trusted-artifact", 10 Mb
"default/api-kflux-rhel-p01-fc38-p1-openshiftapps-com:6443/smodak", "sast-coverity-check-oci-ta", "step-use-trusted-artifact", 0 Mb
"default/api-kflux-stg-es01-21tc-p1-openshiftapps-com:6443/smodak", "sast-coverity-check-oci-ta", "step-use-trusted-artifact", 0 Mb
"default/api-stone-prd-rh01-pg1f-p1-openshiftapps-com:6443/smodak", "sast-coverity-check-oci-ta", "step-use-trusted-artifact", 4962 Mb
"default/api-stone-prod-p02-hjvn-p1-openshiftapps-com:6443/smodak", "sast-coverity-check-oci-ta", "step-use-trusted-artifact", 4098 Mb
"default/api-stone-stage-p01-hpmt-p1-openshiftapps-com:6443/smodak", "sast-coverity-check-oci-ta", "step-use-trusted-artifact", 0 Mb
"default/api-stone-stg-rh01-l2vh-p1-openshiftapps-com:6443/smodak", "sast-coverity-check-oci-ta", "step-use-trusted-artifact", 0 Mb
```

- "**step-build**" is using over 16G, far exceeding the resources defined in 'stepTemplate'. Hence we need to refine it. Memory Usage stats by "step-build":
```shell
"default/api-kflux-ocp-p01-7ayg-p1-openshiftapps-com:6443/smodak", "sast-coverity-check-oci-ta", "step-build", 0 Mb
"default/api-kflux-osp-p01-yt45-p1-openshiftapps-com:6443/smodak", "sast-coverity-check-oci-ta", "step-build", 0 Mb
"default/api-kflux-prd-es01-1ion-p1-openshiftapps-com:6443/smodak", "sast-coverity-check-oci-ta", "step-build", 0 Mb
"default/api-kflux-prd-rh02-0fk9-p1-openshiftapps-com:6443/smodak", "sast-coverity-check-oci-ta", "step-build", 9340 Mb
"default/api-kflux-prd-rh03-nnv1-p1-openshiftapps-com:6443/smodak", "sast-coverity-check-oci-ta", "step-build", 14008 Mb
"default/api-kflux-rhel-p01-fc38-p1-openshiftapps-com:6443/smodak", "sast-coverity-check-oci-ta", "step-build", 0 Mb
"default/api-kflux-stg-es01-21tc-p1-openshiftapps-com:6443/smodak", "sast-coverity-check-oci-ta", "step-build", 0 Mb
"default/api-stone-prd-rh01-pg1f-p1-openshiftapps-com:6443/smodak", "sast-coverity-check-oci-ta", "step-build", 16384 Mb
"default/api-stone-prod-p02-hjvn-p1-openshiftapps-com:6443/smodak", "sast-coverity-check-oci-ta", "step-build", 16386 Mb
"default/api-stone-stage-p01-hpmt-p1-openshiftapps-com:6443/smodak", "sast-coverity-check-oci-ta", "step-build", 0 Mb
"default/api-stone-stg-rh01-l2vh-p1-openshiftapps-com:6443/smodak", "sast-coverity-check-oci-ta", "step-build", 0 Mb
```

- "**step-postprocess**" is using over 15G, far exceeding the resources defined in 'stepTemplate'. Hence we need to refine it as well. Memory Usage stats by "step-postprocess":
```shell
"default/api-kflux-ocp-p01-7ayg-p1-openshiftapps-com:6443/smodak", "sast-coverity-check-oci-ta", "step-postprocess", 0 Mb
"default/api-kflux-osp-p01-yt45-p1-openshiftapps-com:6443/smodak", "sast-coverity-check-oci-ta", "step-postprocess", 0 Mb
"default/api-kflux-prd-es01-1ion-p1-openshiftapps-com:6443/smodak", "sast-coverity-check-oci-ta", "step-postprocess", 0 Mb
"default/api-kflux-prd-rh02-0fk9-p1-openshiftapps-com:6443/smodak", "sast-coverity-check-oci-ta", "step-postprocess", 14915 Mb
"default/api-kflux-prd-rh03-nnv1-p1-openshiftapps-com:6443/smodak", "sast-coverity-check-oci-ta", "step-postprocess", 10 Mb
"default/api-kflux-rhel-p01-fc38-p1-openshiftapps-com:6443/smodak", "sast-coverity-check-oci-ta", "step-postprocess", 0 Mb
"default/api-kflux-stg-es01-21tc-p1-openshiftapps-com:6443/smodak", "sast-coverity-check-oci-ta", "step-postprocess", 0 Mb
"default/api-stone-prd-rh01-pg1f-p1-openshiftapps-com:6443/smodak", "sast-coverity-check-oci-ta", "step-postprocess", 13321 Mb
"default/api-stone-prod-p02-hjvn-p1-openshiftapps-com:6443/smodak", "sast-coverity-check-oci-ta", "step-postprocess", 8958 Mb
"default/api-stone-stage-p01-hpmt-p1-openshiftapps-com:6443/smodak", "sast-coverity-check-oci-ta", "step-postprocess", 0 Mb
"default/api-stone-stg-rh01-l2vh-p1-openshiftapps-com:6443/smodak", "sast-coverity-check-oci-ta", "step-postprocess", 0 Mb
```

This PR intends to set "memory.requests=memory.limits" for all Steps of  task "sast-coverity-check"