### PR TITLE
set 4gb memory request/limit for use-trusted-artifact step in all tasks

### DIFF
--- a/task-generator/trusted-artifacts/golden/buildah/ta.yaml
+++ b/task-generator/trusted-artifacts/golden/buildah/ta.yaml
@@ -136,6 +136,11 @@ spec:
       - use
       - $(params.SOURCE_ARTIFACT)=/var/workdir/source
       - $(params.CACHI2_ARTIFACT)=/var/workdir/cachi2
+    computeResources:
+      limits:
+        memory: 4Gi
+      requests:
+        memory: 4Gi
   - image: quay.io/redhat-appstudio/buildah:v1.31.0@sha256:34f12c7b72ec2c28f1ded0c494b428df4791c909f1f174dd21b8ed6a57cf5ddb
     name: build
     computeResources:

--- a/task-generator/trusted-artifacts/golden/prefetch-dependencies/ta.yaml
+++ b/task-generator/trusted-artifacts/golden/prefetch-dependencies/ta.yaml
@@ -78,6 +78,11 @@ spec:
     args:
       - use
       - $(params.SOURCE_ARTIFACT)=/var/workdir/source
+    computeResources:
+      limits:
+        memory: 4Gi
+      requests:
+        memory: 4Gi
   - image: quay.io/konflux-ci/hermeto:0.29.0@sha256:f577e0399953471df7a9826c1550aef83d28e8b35f76dd65a193441822b629ee
     name: prefetch-dependencies
     env:

--- a/task-generator/trusted-artifacts/golden/sast-snyk-check/ta.yaml
+++ b/task-generator/trusted-artifacts/golden/sast-snyk-check/ta.yaml
@@ -66,6 +66,11 @@ spec:
         - use
         - $(params.SOURCE_ARTIFACT)=/var/workdir/source
         - $(params.CACHI2_ARTIFACT)=/var/workdir/cachi2
+      computeResources:
+        limits:
+          memory: 4Gi
+        requests:
+          memory: 4Gi
     - name: sast-snyk-check
       image: quay.io/konflux-ci/konflux-test:v1.4.0@sha256:54d49b37c9a2e280d42961a57e4f7a16c171d6b065559f1329b548db85300bea
       workingDir: /var/workdir/source

--- a/task-generator/trusted-artifacts/golden/source-build/ta.yaml
+++ b/task-generator/trusted-artifacts/golden/source-build/ta.yaml
@@ -58,6 +58,11 @@ spec:
         - use
         - $(params.SOURCE_ARTIFACT)=/var/workdir/source
         - $(params.CACHI2_ARTIFACT)=/var/workdir/cachi2
+      computeResources:
+        limits:
+          memory: 4Gi
+        requests:
+          memory: 4Gi
     - name: get-base-images
       image: quay.io/konflux-ci/appstudio-utils:48c311af02858e2422d6229600e9959e496ddef1@sha256:91ddd999271f65d8ec8487b10f3dd378f81aa894e11b9af4d10639fd52bba7e8
       env:

--- a/task-generator/trusted-artifacts/ta.go
+++ b/task-generator/trusted-artifacts/ta.go
@@ -318,9 +318,17 @@ func perform(task *pipeline.Task, recipe *Recipe) error {
 		}
 
 		task.Spec.Steps = append([]pipeline.Step{{
-			Name:         "use-trusted-artifact",
-			Image:        image,
-			Args:         args,
+			Name:  "use-trusted-artifact",
+			Image: image,
+			Args:  args,
+			ComputeResources: core.ResourceRequirements{
+				Requests: core.ResourceList{
+					core.ResourceMemory: resource.MustParse("4Gi"),
+				},
+				Limits: core.ResourceList{
+					core.ResourceMemory: resource.MustParse("4Gi"),
+				},
+			},
 			VolumeMounts: recipe.AddTAVolumeMount,
 		}}, task.Spec.Steps...)
 	}

--- a/task/sast-coverity-check-oci-ta/0.3/sast-coverity-check-oci-ta.yaml
+++ b/task/sast-coverity-check-oci-ta/0.3/sast-coverity-check-oci-ta.yaml
@@ -358,6 +358,11 @@ spec:
           name: trusted-ca
           readOnly: true
           subPath: ca-bundle.crt
+      computeResources:
+        limits:
+          memory: 4Gi
+        requests:
+          memory: 4Gi
     - name: prepare
       image: quay.io/redhat-services-prod/sast/coverity:202503.3@sha256:63a6d59a6ffad3de7ea6d0df88ec67001a41cbffaeeee7b4e9ab9337527c92f8
       workingDir: /var/workdir

--- a/task/sast-shell-check-oci-ta-min/0.1/patch.yaml
+++ b/task/sast-shell-check-oci-ta-min/0.1/patch.yaml
@@ -6,6 +6,13 @@
 #     1	sast-shell-check
 #     2	upload
 
+# use-trusted-artifact step
+- op: test
+  path: /spec/steps/0/name
+  value: use-trusted-artifact
+- op: remove
+  path: /spec/steps/0/computeResources
+
 # sast-shell-check step
 - op: test
   path: /spec/steps/1/name

--- a/task/sast-shell-check-oci-ta/0.1/sast-shell-check-oci-ta.yaml
+++ b/task/sast-shell-check-oci-ta/0.1/sast-shell-check-oci-ta.yaml
@@ -96,6 +96,11 @@ spec:
           name: trusted-ca
           readOnly: true
           subPath: ca-bundle.crt
+      computeResources:
+        limits:
+          memory: 4Gi
+        requests:
+          memory: 4Gi
     - name: sast-shell-check
       image: quay.io/konflux-ci/konflux-test:v1.4.52@sha256:deabe80a01dca3a8a0edb709324e30cbf0baa176f7a181bbb695323f506f7aac
       workingDir: /var/workdir/source

--- a/task/sast-snyk-check-oci-ta/0.4/sast-snyk-check-oci-ta.yaml
+++ b/task/sast-snyk-check-oci-ta/0.4/sast-snyk-check-oci-ta.yaml
@@ -117,6 +117,11 @@ spec:
           name: trusted-ca
           readOnly: true
           subPath: ca-bundle.crt
+      computeResources:
+        limits:
+          memory: 4Gi
+        requests:
+          memory: 4Gi
     - name: sast-snyk-check
       image: quay.io/konflux-ci/konflux-test:v1.4.52@sha256:deabe80a01dca3a8a0edb709324e30cbf0baa176f7a181bbb695323f506f7aac
       workingDir: /var/workdir/source

--- a/task/sast-unicode-check-oci-ta-min/0.4/patch.yaml
+++ b/task/sast-unicode-check-oci-ta-min/0.4/patch.yaml
@@ -6,7 +6,14 @@
 #     1	sast-unicode-check
 #     2	upload
 
-# sast-shell-check step
+# use-trusted-artifact step
+- op: test
+  path: /spec/steps/0/name
+  value: use-trusted-artifact
+- op: remove
+  path: /spec/steps/0/computeResources
+
+# sast-unicode-check step
 - op: test
   path: /spec/steps/1/name
   value: sast-unicode-check

--- a/task/sast-unicode-check-oci-ta/0.4/sast-unicode-check-oci-ta.yaml
+++ b/task/sast-unicode-check-oci-ta/0.4/sast-unicode-check-oci-ta.yaml
@@ -88,6 +88,11 @@ spec:
           name: trusted-ca
           readOnly: true
           subPath: ca-bundle.crt
+      computeResources:
+        limits:
+          memory: 4Gi
+        requests:
+          memory: 4Gi
     - name: sast-unicode-check
       image: quay.io/konflux-ci/konflux-test:v1.4.52@sha256:deabe80a01dca3a8a0edb709324e30cbf0baa176f7a181bbb695323f506f7aac
       workingDir: /var/workdir/source


### PR DESCRIPTION
Task generator code for the `create-trusted-artifact` step sets a 3gb limit already so we can do similar for the use step.

Though it's not ideal to diverge from the central generator code there currently isn't an option to set such limits via recipe.yaml.

An alternative would be to set defaults in stepTemplate, but this would affect the other steps of tasks, including `upload`, which typically only needs a very small amount of memory to upload the SARIF report.

In future we should consider using github.com/konflux-ci/task-repo-shared-ci and revisit any divergences in common code.

[PSSECAUT-1550](https://redhat.atlassian.net/browse/PSSECAUT-1550)

[PSSECAUT-1550]: https://redhat.atlassian.net/browse/PSSECAUT-1550?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ