### PR TITLE
feat(sast-snyk-check): add retry logic for transient Snyk API failures

### DIFF
--- a/task/sast-snyk-check-oci-ta/0.4/sast-snyk-check-oci-ta.yaml
+++ b/task/sast-snyk-check-oci-ta/0.4/sast-snyk-check-oci-ta.yaml
@@ -194,6 +194,23 @@ spec:
           exit 0
         fi
 
+        # Wrapper around snyk code test that maps valid non-zero exit codes (1, 3)
+        # to 0 so the existing retry function only retries on exit code 2 (error).
+        # Exit codes: 0 = success, 1 = vulnerabilities found, 2 = error, 3 = no supported files
+        # The real exit code is always preserved in SNYK_EXIT_CODE.
+        # Error codes (2+) always override, valid codes (0, 1, 3) only if no previous error.
+        _snyk_code_test() {
+          snyk code test "$@" 1>&2 >>stdout.txt
+          local ec=$?
+          if [[ "$ec" -ne 0 ]] && [[ "$ec" -ne 1 ]] && [[ "$ec" -ne 3 ]]; then
+            SNYK_EXIT_CODE=$ec
+          fi
+          if [[ "$ec" -eq 1 ]] || [[ "$ec" -eq 3 ]]; then
+            return 0
+          fi
+          return "$ec"
+        }
+
         SNYK_EXIT_CODE=0
         SOURCE_CODE_DIR=/var/workdir
 
@@ -228,14 +245,7 @@ spec:
           echo "INFO: Scanning directory: $resolved_path"
           # We do want to expand ARGS (it can be multiple CLI flags, not just one)
           # shellcheck disable=SC2086
-          snyk code test $ARGS "$resolved_path" --max-depth=1 --sarif-file-output="${resolved_path}/sast_snyk_check_out_${d//\//_}.json" 1>&2 >>stdout.txt
-          cmd_exit_code=$?
-          # Track the exit code: if any snyk command fails, preserve the failure
-          # Exit codes: 0 = success, 1 = vulnerabilities found, 2 = error, 3 = no supported files
-          # Error codes (2+) always override, warning codes (1,3) only if no previous error
-          if [[ "$cmd_exit_code" -ne 0 ]] && [[ "$cmd_exit_code" -ne 1 ]] && [[ "$cmd_exit_code" -ne 3 ]]; then
-            SNYK_EXIT_CODE=$cmd_exit_code
-          fi
+          RETRY_INTERVAL=30 retry _snyk_code_test $ARGS "$resolved_path" --max-depth=1 --sarif-file-output="${resolved_path}/sast_snyk_check_out_${d//\//_}.json"
 
         done
 

--- a/task/sast-snyk-check/0.4/sast-snyk-check.yaml
+++ b/task/sast-snyk-check/0.4/sast-snyk-check.yaml
@@ -165,6 +165,23 @@ spec:
           exit 0
         fi
 
+        # Wrapper around snyk code test that maps valid non-zero exit codes (1, 3)
+        # to 0 so the existing retry function only retries on exit code 2 (error).
+        # Exit codes: 0 = success, 1 = vulnerabilities found, 2 = error, 3 = no supported files
+        # The real exit code is always preserved in SNYK_EXIT_CODE.
+        # Error codes (2+) always override, valid codes (0, 1, 3) only if no previous error.
+        _snyk_code_test() {
+          snyk code test "$@" 1>&2>> stdout.txt
+          local ec=$?
+          if [[ "$ec" -ne 0 ]] && [[ "$ec" -ne 1 ]] && [[ "$ec" -ne 3 ]]; then
+            SNYK_EXIT_CODE=$ec
+          fi
+          if [[ "$ec" -eq 1 ]] || [[ "$ec" -eq 3 ]]; then
+            return 0
+          fi
+          return "$ec"
+        }
+
         SNYK_EXIT_CODE=0
         SOURCE_CODE_DIR=$(workspaces.workspace.path)
 
@@ -199,14 +216,7 @@ spec:
           echo "INFO: Scanning directory: $resolved_path"
           # We do want to expand ARGS (it can be multiple CLI flags, not just one)
           # shellcheck disable=SC2086
-          snyk code test $ARGS "$resolved_path" --max-depth=1 --sarif-file-output="${resolved_path}/sast_snyk_check_out_${d//\//_}.json" 1>&2>> stdout.txt
-          cmd_exit_code=$?
-          # Track the exit code: if any snyk command fails, preserve the failure
-          # Exit codes: 0 = success, 1 = vulnerabilities found, 2 = error, 3 = no supported files
-          # Error codes (2+) always override, warning codes (1,3) only if no previous error
-          if [[ "$cmd_exit_code" -ne 0 ]] && [[ "$cmd_exit_code" -ne 1 ]] && [[ "$cmd_exit_code" -ne 3 ]]; then
-            SNYK_EXIT_CODE=$cmd_exit_code
-          fi
+          RETRY_INTERVAL=30 retry _snyk_code_test $ARGS "$resolved_path" --max-depth=1 --sarif-file-output="${resolved_path}/sast_snyk_check_out_${d//\//_}.json"
 
         done
 

--- a/task/sast-snyk-check/0.4/tests/pre-apply-task-hook.sh
+++ b/task/sast-snyk-check/0.4/tests/pre-apply-task-hook.sh
@@ -15,3 +15,9 @@ echo "Creating snyk secret in namespace: $2"
 kubectl create secret generic snyk-secret \
     --from-literal=snyk_token="$SNYK_TOKEN" \
     --namespace="$2" || true
+
+# Create a secret with an invalid token to test retry on exit code 2
+echo "Creating snyk-bad-token secret in namespace: $2"
+kubectl create secret generic snyk-bad-token \
+    --from-literal=snyk_token="invalid-token" \
+    --namespace="$2" || true

--- a/task/sast-snyk-check/0.4/tests/test-sast-snyk-check-retry.yaml
+++ b/task/sast-snyk-check/0.4/tests/test-sast-snyk-check-retry.yaml
@@ -1,0 +1,68 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-sast-snyk-check-retry
+spec:
+  description: |
+    Test that sast-snyk-check retries on exit code 2 (e.g. bad token / network error)
+    and reports ERROR after exhausting retries.
+  workspaces:
+    - name: tests-workspace
+  tasks:
+    - name: clone-repository
+      workspaces:
+        - name: output
+          workspace: tests-workspace
+      params:
+        - name: url
+          value: https://github.com/konflux-ci/test-data-sast
+        - name: revision
+          value: main
+      taskRef:
+        resolver: git
+        params:
+          - name: url
+            value: https://github.com/konflux-ci/build-definitions.git
+          - name: revision
+            value: main
+          - name: pathInRepo
+            value: task/git-clone/0.1/git-clone.yaml
+    - name: scan-with-snyk
+      runAfter:
+        - clone-repository
+      workspaces:
+        - name: workspace
+          workspace: tests-workspace
+      taskRef:
+        name: sast-snyk-check
+      params:
+        - name: SNYK_SECRET
+          value: snyk-bad-token
+        - name: image-url
+          value: ""
+        - name: image-digest
+          value: sha256:a6e305864fefbce727a3d8cc9f0277eede5f0617696f9cda486b1f6b3b94f7cb
+    - name: check-result
+      runAfter:
+        - scan-with-snyk
+      params:
+        - name: results
+          value: $(tasks.scan-with-snyk.results.TEST_OUTPUT)
+      taskSpec:
+        params:
+          - name: results
+        steps:
+          - name: check-result
+            image: quay.io/konflux-ci/konflux-test:v1.4.52@sha256:deabe80a01dca3a8a0edb709324e30cbf0baa176f7a181bbb695323f506f7aac
+            env:
+            - name: RESULTS
+              value: $(params.results)
+            script: |
+              #!/bin/bash
+
+              set -e
+
+              echo "$RESULTS"
+              echo -n "Expected ERROR result after retry exhaustion: "
+              echo "$RESULTS" | jq -e '.result == "ERROR"'


### PR DESCRIPTION
Retry snyk code test up to 3 times with 30s interval on exit code 2, which should cover transient network errors (504 timeout, TLS handshake timeout, invalid token etc).

Adds a test pipeline using a bad token to verify retry on exit code 2.

Ref: PSSECAUT-1558