### PR TITLE
feat(sast-unicode-check): add TARGET_DIRS param

### DIFF
--- a/task/sast-unicode-check-oci-ta-min/0.4/README.md
+++ b/task/sast-unicode-check-oci-ta-min/0.4/README.md
@@ -11,6 +11,7 @@ Scans source code for non-printable unicode characters in all text files.
 |PROJECT_NAME|Name of the scanned project, used to find path exclusions. By default, the Konflux component name will be used.|""|false|
 |RECORD_EXCLUDED|Whether to record the excluded findings (defaults to false). If `true`, the excluded findings will be stored in `excluded-findings.json`. |false|false|
 |SOURCE_ARTIFACT|The Trusted Artifact URI pointing to the artifact with the application source code.||true|
+|TARGET_DIRS|Target directories in component's source code. Multiple values should be separated with commas.|.|false|
 |caTrustConfigMapKey|The name of the key in the ConfigMap that contains the CA bundle data.|ca-bundle.crt|false|
 |caTrustConfigMapName|The name of the ConfigMap to read CA bundle data from.|trusted-ca|false|
 |image-digest|Image digest used for ORAS upload.||true|

--- a/task/sast-unicode-check-oci-ta-min/0.4/sast-unicode-check-oci-ta-min.yaml
+++ b/task/sast-unicode-check-oci-ta-min/0.4/sast-unicode-check-oci-ta-min.yaml
@@ -44,6 +44,11 @@ spec:
       source code.
     name: SOURCE_ARTIFACT
     type: string
+  - default: .
+    description: Target directories in component's source code. Multiple values should
+      be separated with commas.
+    name: TARGET_DIRS
+    type: string
   - default: ca-bundle.crt
     description: The name of the key in the ConfigMap that contains the CA bundle
       data.
@@ -93,6 +98,8 @@ spec:
       value: $(params.FIND_UNICODE_CONTROL_ARGS)
     - name: RECORD_EXCLUDED
       value: $(params.RECORD_EXCLUDED)
+    - name: TARGET_DIRS
+      value: $(params.TARGET_DIRS)
     - name: SOURCE_CODE_DIR
       value: /var/workdir
     - name: COMPONENT_LABEL
@@ -129,8 +136,17 @@ spec:
       SCAN_PROP="https://github.com/siddhesh/find-unicode-control.git#c2accbfbba7553a8bc1ebd97089ae08ad8347e58"
       FUC_EXIT_CODE=0
 
+      # generate full path for each dirname separated by comma
+      declare -a ALL_TARGETS
+      OLD_IFS="$IFS"
+      IFS=","
+      for d in $TARGET_DIRS; do
+        ALL_TARGETS+=("${SOURCE_CODE_DIR}/source/${d}")
+      done
+      IFS="$OLD_IFS"
+
       # shellcheck disable=SC2086
-      LANG=en_US.utf8 find_unicode_control.py ${FIND_UNICODE_CONTROL_ARGS} "${SOURCE_CODE_DIR}/source" \
+      LANG=en_US.utf8 find_unicode_control.py ${FIND_UNICODE_CONTROL_ARGS} "${ALL_TARGETS[@]}" \
         >raw_sast_unicode_check_out.txt \
         2>raw_sast_unicode_check_out.log ||
         FUC_EXIT_CODE=$?

--- a/task/sast-unicode-check-oci-ta/0.4/MIGRATION.md
+++ b/task/sast-unicode-check-oci-ta/0.4/MIGRATION.md
@@ -5,3 +5,13 @@
 ## Action from users
 
 - If your pipeline uses the FIND_UNICODE_CONTROL_URL parameter, then it should be removed.
+
+# Migration from 0.4 to 0.4.1
+
+Version 0.4.1:
+
+* Add the optional `TARGET_DIRS` parameter.
+
+## Action from users
+
+- No action required. The default value of "." preserves the existing behavior.

--- a/task/sast-unicode-check-oci-ta/0.4/README.md
+++ b/task/sast-unicode-check-oci-ta/0.4/README.md
@@ -11,6 +11,7 @@ Scans source code for non-printable unicode characters in all text files.
 |PROJECT_NAME|Name of the scanned project, used to find path exclusions. By default, the Konflux component name will be used.|""|false|
 |RECORD_EXCLUDED|Whether to record the excluded findings (defaults to false). If `true`, the excluded findings will be stored in `excluded-findings.json`. |false|false|
 |SOURCE_ARTIFACT|The Trusted Artifact URI pointing to the artifact with the application source code.||true|
+|TARGET_DIRS|Target directories in component's source code. Multiple values should be separated with commas.|.|false|
 |caTrustConfigMapKey|The name of the key in the ConfigMap that contains the CA bundle data.|ca-bundle.crt|false|
 |caTrustConfigMapName|The name of the ConfigMap to read CA bundle data from.|trusted-ca|false|
 |image-digest|Image digest used for ORAS upload.||true|

--- a/task/sast-unicode-check-oci-ta/0.4/sast-unicode-check-oci-ta.yaml
+++ b/task/sast-unicode-check-oci-ta/0.4/sast-unicode-check-oci-ta.yaml
@@ -44,6 +44,11 @@ spec:
       description: The Trusted Artifact URI pointing to the artifact with
         the application source code.
       type: string
+    - name: TARGET_DIRS
+      description: Target directories in component's source code. Multiple
+        values should be separated with commas.
+      type: string
+      default: .
     - name: caTrustConfigMapKey
       description: The name of the key in the ConfigMap that contains the
         CA bundle data.
@@ -109,6 +114,8 @@ spec:
           value: $(params.FIND_UNICODE_CONTROL_ARGS)
         - name: RECORD_EXCLUDED
           value: $(params.RECORD_EXCLUDED)
+        - name: TARGET_DIRS
+          value: $(params.TARGET_DIRS)
         - name: SOURCE_CODE_DIR
           value: /var/workdir
         - name: COMPONENT_LABEL
@@ -143,8 +150,17 @@ spec:
         SCAN_PROP="https://github.com/siddhesh/find-unicode-control.git#c2accbfbba7553a8bc1ebd97089ae08ad8347e58"
         FUC_EXIT_CODE=0
 
+        # generate full path for each dirname separated by comma
+        declare -a ALL_TARGETS
+        OLD_IFS="$IFS"
+        IFS=","
+        for d in $TARGET_DIRS; do
+          ALL_TARGETS+=("${SOURCE_CODE_DIR}/source/${d}")
+        done
+        IFS="$OLD_IFS"
+
         # shellcheck disable=SC2086
-        LANG=en_US.utf8 find_unicode_control.py ${FIND_UNICODE_CONTROL_ARGS} "${SOURCE_CODE_DIR}/source" \
+        LANG=en_US.utf8 find_unicode_control.py ${FIND_UNICODE_CONTROL_ARGS} "${ALL_TARGETS[@]}" \
           >raw_sast_unicode_check_out.txt \
           2>raw_sast_unicode_check_out.log ||
           FUC_EXIT_CODE=$?

--- a/task/sast-unicode-check/0.4/MIGRATION.md
+++ b/task/sast-unicode-check/0.4/MIGRATION.md
@@ -5,3 +5,13 @@
 ## Action from users
 
 - If your pipeline uses the FIND_UNICODE_CONTROL_URL parameter, then it should be removed.
+
+# Migration from 0.4 to 0.4.1
+
+Version 0.4.1:
+
+* Add the optional `TARGET_DIRS` parameter.
+
+## Action from users
+
+- No action required. The default value of "." preserves the existing behavior.

--- a/task/sast-unicode-check/0.4/README.md
+++ b/task/sast-unicode-check/0.4/README.md
@@ -11,6 +11,7 @@ Scans source code for non-printable unicode characters in all text files.
 |KFP_GIT_URL|Known False Positives (KFP) git URL (optionally taking a revision delimited by \#). Defaults to "SITE_DEFAULT", which means the default value "https://gitlab.cee.redhat.com/osh/known-false-positives.git" for internal Konflux instance and empty string for external Konflux instance. If set to an empty string, the KFP filtering is disabled.|SITE_DEFAULT|false|
 |PROJECT_NAME|Name of the scanned project, used to find path exclusions. By default, the Konflux component name will be used.|""|false|
 |RECORD_EXCLUDED|Whether to record the excluded findings (defaults to false). If `true`, the excluded findings will be stored in `excluded-findings.json`. |false|false|
+|TARGET_DIRS|Target directories in component's source code. Multiple values should be separated with commas.|.|false|
 |caTrustConfigMapName|The name of the ConfigMap to read CA bundle data from.|trusted-ca|false|
 |caTrustConfigMapKey|The name of the key in the ConfigMap that contains the CA bundle data.|ca-bundle.crt|false|
 

--- a/task/sast-unicode-check/0.4/sast-unicode-check.yaml
+++ b/task/sast-unicode-check/0.4/sast-unicode-check.yaml
@@ -42,6 +42,10 @@ spec:
         Whether to record the excluded findings (defaults to false).
         If `true`, the excluded findings will be stored in `excluded-findings.json`.
       default: "false"
+    - name: TARGET_DIRS
+      type: string
+      description: Target directories in component's source code. Multiple values should be separated with commas.
+      default: "."
     - name: caTrustConfigMapName
       type: string
       description: The name of the ConfigMap to read CA bundle data from.
@@ -84,6 +88,8 @@ spec:
           value: $(params.FIND_UNICODE_CONTROL_ARGS)
         - name: RECORD_EXCLUDED
           value: $(params.RECORD_EXCLUDED)
+        - name: TARGET_DIRS
+          value: $(params.TARGET_DIRS)
         - name: SOURCE_CODE_DIR
           value: $(workspaces.workspace.path)
         - name: COMPONENT_LABEL
@@ -118,8 +124,17 @@ spec:
         SCAN_PROP="https://github.com/siddhesh/find-unicode-control.git#c2accbfbba7553a8bc1ebd97089ae08ad8347e58"
         FUC_EXIT_CODE=0
 
+        # generate full path for each dirname separated by comma
+        declare -a ALL_TARGETS
+        OLD_IFS="$IFS"
+        IFS=","
+        for d in $TARGET_DIRS; do
+          ALL_TARGETS+=("${SOURCE_CODE_DIR}/source/${d}")
+        done
+        IFS="$OLD_IFS"
+
         # shellcheck disable=SC2086
-        LANG=en_US.utf8 find_unicode_control.py ${FIND_UNICODE_CONTROL_ARGS} "${SOURCE_CODE_DIR}/source" \
+        LANG=en_US.utf8 find_unicode_control.py ${FIND_UNICODE_CONTROL_ARGS} "${ALL_TARGETS[@]}" \
             >raw_sast_unicode_check_out.txt \
             2>raw_sast_unicode_check_out.log \
             || FUC_EXIT_CODE=$?


### PR DESCRIPTION
Add optional TARGET_DIRS parameter to allow scanning specific directories within the source tree. Multiple values are comma-separated. Defaults to "." for backward compatibility.

Ref: PSSECAUT-1528