### PR TITLE
feat(sast-shell-check): add SKIP_JINJA param to skip Jinja2 templates

### DIFF
--- a/task/sast-shell-check-oci-ta-min/0.1/README.md
+++ b/task/sast-shell-check-oci-ta-min/0.1/README.md
@@ -11,6 +11,7 @@ ShellCheck is a static analysis tool, gives warnings and suggestions for bash/sh
 |KFP_GIT_URL|Known False Positives (KFP) git URL (optionally taking a revision delimited by \#). Defaults to "SITE_DEFAULT", which means the default value "https://gitlab.cee.redhat.com/osh/known-false-positives.git" for internal Konflux instance and empty string for external Konflux instance. If set to an empty string, the KFP filtering is disabled.|SITE_DEFAULT|false|
 |PROJECT_NAME|Name of the scanned project, used to find path exclusions. By default, the Konflux component name will be used.|""|false|
 |RECORD_EXCLUDED|Whether to record the excluded findings (default to false). If `true`, the excluded findings will be stored in `excluded-findings.json`. |false|false|
+|SKIP_JINJA|Whether to skip files containing Jinja2 template syntax ({{ }}, {% %}, {# #}). ShellCheck cannot parse Jinja2 constructs, so scanning such files produces unreliable findings.|true|false|
 |SOURCE_ARTIFACT|The Trusted Artifact URI pointing to the artifact with the application source code.||true|
 |TARGET_DIRS|Target directories in component's source code. Multiple values should be separated with commas.|.|false|
 |caTrustConfigMapKey|The name of the key in the ConfigMap that contains the CA bundle data.|ca-bundle.crt|false|

--- a/task/sast-shell-check-oci-ta-min/0.1/sast-shell-check-oci-ta-min.yaml
+++ b/task/sast-shell-check-oci-ta-min/0.1/sast-shell-check-oci-ta-min.yaml
@@ -41,6 +41,12 @@ spec:
       If `true`, the excluded findings will be stored in `excluded-findings.json`.
     name: RECORD_EXCLUDED
     type: string
+  - default: "true"
+    description: 'Whether to skip files containing Jinja2 template syntax ({{ }},
+      {% %}, {# #}). ShellCheck cannot parse Jinja2 constructs, so scanning such files
+      produces unreliable findings.'
+    name: SKIP_JINJA
+    type: string
   - description: The Trusted Artifact URI pointing to the artifact with the application
       source code.
     name: SOURCE_ARTIFACT
@@ -104,6 +110,8 @@ spec:
       value: $(params.IMP_FINDINGS_ONLY)
     - name: TARGET_DIRS
       value: $(params.TARGET_DIRS)
+    - name: SKIP_JINJA
+      value: $(params.SKIP_JINJA)
     - name: COMPONENT_LABEL
       valueFrom:
         fieldRef:
@@ -164,6 +172,10 @@ spec:
           export SC_JOBS=$(((quota + period - 1) / period))
           echo "INFO: Setting SC_JOBS=${SC_JOBS} based on cgroups v2 max for run-shellcheck.sh"
         fi
+      fi
+
+      if [[ "${SKIP_JINJA}" == "true" ]]; then
+        export SC_SKIP_JINJA=1
       fi
 
       # generate all shellcheck result JSON files to $SC_RESULTS_DIR, which defaults to ./shellcheck-results/

--- a/task/sast-shell-check-oci-ta/0.1/README.md
+++ b/task/sast-shell-check-oci-ta/0.1/README.md
@@ -11,6 +11,7 @@ ShellCheck is a static analysis tool, gives warnings and suggestions for bash/sh
 |KFP_GIT_URL|Known False Positives (KFP) git URL (optionally taking a revision delimited by \#). Defaults to "SITE_DEFAULT", which means the default value "https://gitlab.cee.redhat.com/osh/known-false-positives.git" for internal Konflux instance and empty string for external Konflux instance. If set to an empty string, the KFP filtering is disabled.|SITE_DEFAULT|false|
 |PROJECT_NAME|Name of the scanned project, used to find path exclusions. By default, the Konflux component name will be used.|""|false|
 |RECORD_EXCLUDED|Whether to record the excluded findings (default to false). If `true`, the excluded findings will be stored in `excluded-findings.json`. |false|false|
+|SKIP_JINJA|Whether to skip files containing Jinja2 template syntax ({{ }}, {% %}, {# #}). ShellCheck cannot parse Jinja2 constructs, so scanning such files produces unreliable findings.|true|false|
 |SOURCE_ARTIFACT|The Trusted Artifact URI pointing to the artifact with the application source code.||true|
 |TARGET_DIRS|Target directories in component's source code. Multiple values should be separated with commas.|.|false|
 |caTrustConfigMapKey|The name of the key in the ConfigMap that contains the CA bundle data.|ca-bundle.crt|false|

--- a/task/sast-shell-check-oci-ta/0.1/sast-shell-check-oci-ta.yaml
+++ b/task/sast-shell-check-oci-ta/0.1/sast-shell-check-oci-ta.yaml
@@ -41,6 +41,12 @@ spec:
         If `true`, the excluded findings will be stored in `excluded-findings.json`.
       type: string
       default: "false"
+    - name: SKIP_JINJA
+      description: 'Whether to skip files containing Jinja2 template syntax
+        ({{ }}, {% %}, {# #}). ShellCheck cannot parse Jinja2 constructs,
+        so scanning such files produces unreliable findings.'
+      type: string
+      default: "true"
     - name: SOURCE_ARTIFACT
       description: The Trusted Artifact URI pointing to the artifact with
         the application source code.
@@ -119,6 +125,8 @@ spec:
           value: $(params.IMP_FINDINGS_ONLY)
         - name: TARGET_DIRS
           value: $(params.TARGET_DIRS)
+        - name: SKIP_JINJA
+          value: $(params.SKIP_JINJA)
         - name: COMPONENT_LABEL
           valueFrom:
             fieldRef:
@@ -177,6 +185,10 @@ spec:
             export SC_JOBS=$(((quota + period - 1) / period))
             echo "INFO: Setting SC_JOBS=${SC_JOBS} based on cgroups v2 max for run-shellcheck.sh"
           fi
+        fi
+
+        if [[ "${SKIP_JINJA}" == "true" ]]; then
+          export SC_SKIP_JINJA=1
         fi
 
         # generate all shellcheck result JSON files to $SC_RESULTS_DIR, which defaults to ./shellcheck-results/

--- a/task/sast-shell-check/0.1/README.md
+++ b/task/sast-shell-check/0.1/README.md
@@ -13,6 +13,7 @@ ShellCheck is a static analysis tool, gives warnings and suggestions for bash/sh
 |RECORD_EXCLUDED|Whether to record the excluded findings (default to false). If `true`, the excluded findings will be stored in `excluded-findings.json`. |false|false|
 |IMP_FINDINGS_ONLY|Whether to include important findings only|true|false|
 |TARGET_DIRS|Target directories in component's source code. Multiple values should be separated with commas.|.|false|
+|SKIP_JINJA|Whether to skip files containing Jinja2 template syntax. ShellCheck cannot parse Jinja2 constructs, so scanning such files produces unreliable findings.|true|false|
 |caTrustConfigMapName|The name of the ConfigMap to read CA bundle data from.|trusted-ca|false|
 |caTrustConfigMapKey|The name of the key in the ConfigMap that contains the CA bundle data.|ca-bundle.crt|false|
 

--- a/task/sast-shell-check/0.1/sast-shell-check.yaml
+++ b/task/sast-shell-check/0.1/sast-shell-check.yaml
@@ -50,6 +50,12 @@ spec:
       type: string
       description: Target directories in component's source code. Multiple values should be separated with commas.
       default: "."
+    - name: SKIP_JINJA
+      type: string
+      description: >-
+        Whether to skip files containing Jinja2 template syntax ({{ }}, {% %}, {# #}).
+        ShellCheck cannot parse Jinja2 constructs, so scanning such files produces unreliable findings.
+      default: "true"
     - name: caTrustConfigMapName
       type: string
       description: The name of the ConfigMap to read CA bundle data from.
@@ -94,6 +100,8 @@ spec:
           value: $(params.IMP_FINDINGS_ONLY)
         - name: TARGET_DIRS
           value: $(params.TARGET_DIRS)
+        - name: SKIP_JINJA
+          value: $(params.SKIP_JINJA)
         - name: COMPONENT_LABEL
           valueFrom:
             fieldRef:
@@ -152,6 +160,10 @@ spec:
                 export SC_JOBS=$(((quota + period - 1) / period))
                 echo "INFO: Setting SC_JOBS=${SC_JOBS} based on cgroups v2 max for run-shellcheck.sh"
             fi
+        fi
+
+        if [[ "${SKIP_JINJA}" == "true" ]]; then
+            export SC_SKIP_JINJA=1
         fi
 
         # generate all shellcheck result JSON files to $SC_RESULTS_DIR, which defaults to ./shellcheck-results/


### PR DESCRIPTION
Expose the SC_SKIP_JINJA option from csmock-plugin-shellcheck as a Tekton task parameter. ShellCheck cannot parse Jinja2 template syntax ({{ }}, {% %}, {# #}), producing unreliable findings on files that contain these constructs. Enabled by default to reduce noise.

~Requires csmock >= 3.8.6 in the konflux-test image:~

~https://github.com/konflux-ci/konflux-test/pull/844~

Requires csmock >= 3.8.7 in the konflux-test image:

https://github.com/konflux-ci/konflux-test/pull/869

Ref: https://redhat.atlassian.net/browse/PSSECAUT-1577