### PR TITLE
fix(sast): correct SOURCE_CODE_DIR in snyk and gitleaks tasks

### DIFF
--- a/task/sast-gitleaks-check-oci-ta/0.1/sast-gitleaks-check-oci-ta.yaml
+++ b/task/sast-gitleaks-check-oci-ta/0.1/sast-gitleaks-check-oci-ta.yaml
@@ -143,7 +143,7 @@ spec:
           update-ca-trust
         fi
 
-        SOURCE_CODE_DIR=/var/workdir
+        SOURCE_CODE_DIR=/var/workdir/source
 
         set +e
         echo "INFO: Running 'gitleaks dir'.."

--- a/task/sast-gitleaks-check/0.1/sast-gitleaks-check.yaml
+++ b/task/sast-gitleaks-check/0.1/sast-gitleaks-check.yaml
@@ -114,7 +114,7 @@ spec:
           update-ca-trust
         fi
 
-        SOURCE_CODE_DIR=$(workspaces.workspace.path)
+        SOURCE_CODE_DIR=$(workspaces.workspace.path)/source
 
         set +e
         echo "INFO: Running 'gitleaks dir'.."

--- a/task/sast-snyk-check-oci-ta/0.4/sast-snyk-check-oci-ta.yaml
+++ b/task/sast-snyk-check-oci-ta/0.4/sast-snyk-check-oci-ta.yaml
@@ -212,11 +212,11 @@ spec:
         }
 
         SNYK_EXIT_CODE=0
-        SOURCE_CODE_DIR=/var/workdir
+        SOURCE_CODE_DIR=/var/workdir/source
 
         # We ignore files using snyk ignore if the user set up the IGNORE_FILE_PATHS variable.
         (cd "${SOURCE_CODE_DIR}" && IFS="," && for path in $IGNORE_FILE_PATHS; do
-          snyk ignore --file-path="source/${path}"
+          snyk ignore --file-path="${path}"
         done)
 
         set +e
@@ -284,9 +284,8 @@ spec:
           fi
 
           # In order to generate csdiff/v1, we need to add the whole path of the source code as Snyk only provides an URI to embed the context
-          (cd "${SOURCE_CODE_DIR}" && csgrep --mode=json --embed-context=3 "${SOURCE_CODE_DIR}"/sast_snyk_check_out.json) |
-            csgrep --mode=json --strip-path-prefix="source/" \
-              >sast_snyk_check_out_all_findings.json
+          (cd "${SOURCE_CODE_DIR}" && csgrep --mode=json --embed-context=3 "${SOURCE_CODE_DIR}"/sast_snyk_check_out.json) \
+            >sast_snyk_check_out_all_findings.json
 
           echo "INFO: Initial results:"
           csgrep --mode=evtstat sast_snyk_check_out_all_findings.json

--- a/task/sast-snyk-check-oci-ta/0.5/sast-snyk-check-oci-ta.yaml
+++ b/task/sast-snyk-check-oci-ta/0.5/sast-snyk-check-oci-ta.yaml
@@ -311,11 +311,11 @@ spec:
         }
 
         SNYK_EXIT_CODE=0
-        SOURCE_CODE_DIR=/var/workdir
+        SOURCE_CODE_DIR=/var/workdir/source
 
         # We ignore files using snyk ignore if the user set up the IGNORE_FILE_PATHS variable.
         (cd "${SOURCE_CODE_DIR}" && IFS="," && for path in $IGNORE_FILE_PATHS; do
-          snyk ignore --file-path="source/${path}"
+          snyk ignore --file-path="${path}"
         done)
 
         set +e
@@ -383,9 +383,8 @@ spec:
           fi
 
           # In order to generate csdiff/v1, we need to add the whole path of the source code as Snyk only provides an URI to embed the context
-          (cd "${SOURCE_CODE_DIR}" && csgrep --mode=json --embed-context=3 "${SOURCE_CODE_DIR}"/sast_snyk_check_out.json) |
-            csgrep --mode=json --strip-path-prefix="source/" \
-              >sast_snyk_check_out_all_findings.json
+          (cd "${SOURCE_CODE_DIR}" && csgrep --mode=json --embed-context=3 "${SOURCE_CODE_DIR}"/sast_snyk_check_out.json) \
+            >sast_snyk_check_out_all_findings.json
 
           echo "INFO: Initial results:"
           csgrep --mode=evtstat sast_snyk_check_out_all_findings.json

--- a/task/sast-snyk-check/0.4/sast-snyk-check.yaml
+++ b/task/sast-snyk-check/0.4/sast-snyk-check.yaml
@@ -183,11 +183,11 @@ spec:
         }
 
         SNYK_EXIT_CODE=0
-        SOURCE_CODE_DIR=$(workspaces.workspace.path)
+        SOURCE_CODE_DIR=$(workspaces.workspace.path)/source
 
         # We ignore files using snyk ignore if the user set up the IGNORE_FILE_PATHS variable.
         (cd "${SOURCE_CODE_DIR}" && IFS="," && for path in $IGNORE_FILE_PATHS; do
-          snyk ignore --file-path="source/${path}"
+          snyk ignore --file-path="${path}"
         done)
 
         set +e
@@ -256,7 +256,6 @@ spec:
 
           # In order to generate csdiff/v1, we need to add the whole path of the source code as Snyk only provides an URI to embed the context
           (cd  "${SOURCE_CODE_DIR}" && csgrep --mode=json --embed-context=3 "${SOURCE_CODE_DIR}"/sast_snyk_check_out.json) \
-            | csgrep --mode=json --strip-path-prefix="source/"  \
             > sast_snyk_check_out_all_findings.json
 
           echo "INFO: Initial results:"

--- a/task/sast-snyk-check/0.4/tests/test-sast-snyk-check-target-dirs.yaml
+++ b/task/sast-snyk-check/0.4/tests/test-sast-snyk-check-target-dirs.yaml
@@ -1,0 +1,90 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-sast-snyk-check-target-dirs
+spec:
+  description: |
+    Test that sast-snyk-check resolves TARGET_DIRS relative to the source
+    checkout directory, not the workspace root.
+  workspaces:
+    - name: tests-workspace
+  tasks:
+    - name: init
+      taskRef:
+        resolver: git
+        params:
+          - name: url
+            value: https://github.com/konflux-ci/build-definitions.git
+          - name: revision
+            value: main
+          - name: pathInRepo
+            value: task/init/0.2/init.yaml
+      params:
+        - name: image-url
+          value: "quay.io/redhat-user-workloads/sast-tests-tenant/tests/tests-sast-shell-check:latest"
+    - name: clone-repository
+      runAfter:
+        - init
+      workspaces:
+        - name: output
+          workspace: tests-workspace
+      params:
+        - name: url
+          value: https://github.com/konflux-ci/test-data-sast
+        - name: revision
+          value: main
+      taskRef:
+        resolver: git
+        params:
+          - name: url
+            value: https://github.com/konflux-ci/build-definitions.git
+          - name: revision
+            value: main
+          - name: pathInRepo
+            value: task/git-clone/0.1/git-clone.yaml
+    - name: scan-with-snyk
+      runAfter:
+        - clone-repository
+      workspaces:
+        - name: workspace
+          workspace: tests-workspace
+      taskRef:
+        name: sast-snyk-check
+      params:
+        - name: image-url
+          value: ""
+        - name: image-digest
+          value: sha256:a6e305864fefbce727a3d8cc9f0277eede5f0617696f9cda486b1f6b3b94f7cb
+        - name: TARGET_DIRS
+          value: "test-project"
+    - name: check-result
+      runAfter:
+        - scan-with-snyk
+      workspaces:
+        - name: workspace
+          workspace: tests-workspace
+      params:
+        - name: results
+          value: $(tasks.scan-with-snyk.results.TEST_OUTPUT)
+      taskSpec:
+        params:
+          - name: results
+        steps:
+          - name: check-result
+            image: quay.io/konflux-ci/konflux-test:v1.5.1@sha256:e6b090c515168c8ed0fa932ffe0ac6f27dbc1ea41fdb2fe83cfcaa7829b910bd
+            workingDir: $(workspaces.workspace.path)
+            env:
+            - name: RESULTS
+              value: $(params.results)
+            script: |
+              #!/bin/bash
+
+              set -e
+
+              echo "$RESULTS"
+              echo -n "Expected result: "
+              echo "$RESULTS" | jq -e '.result == "FAILURE" and .successes == 0 and .failures == 1 and .warnings == 0'
+
+              report=$(find . -name 'sast_snyk_check_out.sarif')
+              jq -e 'select(.inlineExternalProperties[0].externalizedProperties["analyzer-version-snyk-code"] != null)' "$report"

--- a/task/sast-snyk-check/0.5/sast-snyk-check.yaml
+++ b/task/sast-snyk-check/0.5/sast-snyk-check.yaml
@@ -187,11 +187,11 @@ spec:
         }
 
         SNYK_EXIT_CODE=0
-        SOURCE_CODE_DIR=$(workspaces.workspace.path)
+        SOURCE_CODE_DIR=$(workspaces.workspace.path)/source
 
         # We ignore files using snyk ignore if the user set up the IGNORE_FILE_PATHS variable.
         (cd "${SOURCE_CODE_DIR}" && IFS="," && for path in $IGNORE_FILE_PATHS; do
-          snyk ignore --file-path="source/${path}"
+          snyk ignore --file-path="${path}"
         done)
 
         set +e
@@ -260,7 +260,6 @@ spec:
 
           # In order to generate csdiff/v1, we need to add the whole path of the source code as Snyk only provides an URI to embed the context
           (cd  "${SOURCE_CODE_DIR}" && csgrep --mode=json --embed-context=3 "${SOURCE_CODE_DIR}"/sast_snyk_check_out.json) \
-            | csgrep --mode=json --strip-path-prefix="source/"  \
             > sast_snyk_check_out_all_findings.json
 
           echo "INFO: Initial results:"

--- a/task/sast-snyk-check/0.5/tests/test-sast-snyk-check-target-dirs.yaml
+++ b/task/sast-snyk-check/0.5/tests/test-sast-snyk-check-target-dirs.yaml
@@ -1,0 +1,90 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-sast-snyk-check-target-dirs
+spec:
+  description: |
+    Test that sast-snyk-check resolves TARGET_DIRS relative to the source
+    checkout directory, not the workspace root.
+  workspaces:
+    - name: tests-workspace
+  tasks:
+    - name: init
+      taskRef:
+        resolver: git
+        params:
+          - name: url
+            value: https://github.com/konflux-ci/build-definitions.git
+          - name: revision
+            value: main
+          - name: pathInRepo
+            value: task/init/0.2/init.yaml
+      params:
+        - name: image-url
+          value: "quay.io/redhat-user-workloads/sast-tests-tenant/tests/tests-sast-shell-check:latest"
+    - name: clone-repository
+      runAfter:
+        - init
+      workspaces:
+        - name: output
+          workspace: tests-workspace
+      params:
+        - name: url
+          value: https://github.com/konflux-ci/test-data-sast
+        - name: revision
+          value: main
+      taskRef:
+        resolver: git
+        params:
+          - name: url
+            value: https://github.com/konflux-ci/build-definitions.git
+          - name: revision
+            value: main
+          - name: pathInRepo
+            value: task/git-clone/0.1/git-clone.yaml
+    - name: scan-with-snyk
+      runAfter:
+        - clone-repository
+      workspaces:
+        - name: workspace
+          workspace: tests-workspace
+      taskRef:
+        name: sast-snyk-check
+      params:
+        - name: image-url
+          value: ""
+        - name: image-digest
+          value: sha256:a6e305864fefbce727a3d8cc9f0277eede5f0617696f9cda486b1f6b3b94f7cb
+        - name: TARGET_DIRS
+          value: "test-project"
+    - name: check-result
+      runAfter:
+        - scan-with-snyk
+      workspaces:
+        - name: workspace
+          workspace: tests-workspace
+      params:
+        - name: results
+          value: $(tasks.scan-with-snyk.results.TEST_OUTPUT)
+      taskSpec:
+        params:
+          - name: results
+        steps:
+          - name: check-result
+            image: quay.io/konflux-ci/konflux-test:v1.5.1@sha256:e6b090c515168c8ed0fa932ffe0ac6f27dbc1ea41fdb2fe83cfcaa7829b910bd
+            workingDir: $(workspaces.workspace.path)
+            env:
+            - name: RESULTS
+              value: $(params.results)
+            script: |
+              #!/bin/bash
+
+              set -e
+
+              echo "$RESULTS"
+              echo -n "Expected result: "
+              echo "$RESULTS" | jq -e '.result == "FAILURE" and .successes == 0 and .failures == 1 and .warnings == 0'
+
+              report=$(find . -name 'sast_snyk_check_out.sarif')
+              jq -e 'select(.inlineExternalProperties[0].externalizedProperties["analyzer-version-snyk-code"] != null)' "$report"


### PR DESCRIPTION
Both sast-snyk-check and sast-gitleaks-check set SOURCE_CODE_DIR to the
workspace root instead of the source checkout directory. This causes
TARGET_DIRS values to resolve against the wrong parent, silently
breaking scans when specific subdirectories are specified.

The bug dates back to babf5bc, which added TARGET_DIRS support to
sast-snyk-check. The tests set TARGET_DIRS=source/gcc instead of
TARGET_DIRS=gcc to work around the wrong SOURCE_CODE_DIR, which made
CI pass but masked the issue for real users.

Fix SOURCE_CODE_DIR to include /source suffix, matching the convention
used by sast-shell-check and sast-coverity-check. Also remove the
compensating "source/" prefixes in snyk's IGNORE_FILE_PATHS handling
and the now-unnecessary csgrep --strip-path-prefix="source/".

Add a regression test that sets TARGET_DIRS=test-project (without source/
prefix) to catch future regressions.

Resolves: PSSECAUT-1596