### PR TITLE
fix(sast-shell-check): add pre-apply hook to zero computeResources

### DIFF
--- a/task/sast-shell-check/0.1/tests/pre-apply-task-hook.sh
+++ b/task/sast-shell-check/0.1/tests/pre-apply-task-hook.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+echo "Removing computeResources for task: $1"
+yq -i eval '.spec.steps[0].computeResources = {}' $1
+yq -i eval '.spec.steps[1].computeResources = {}' $1


### PR DESCRIPTION
Prevents CI test pods from failing to schedule due to resource limits by clearing computeResources for both task steps before applying.