### PR TITLE
fix(PSSECAUT-1385): fix SARIF merging for multi TARGET_DIRS in sast-snyk-check

### DIFF
--- a/task/sast-snyk-check-oci-ta/0.5/sast-snyk-check-oci-ta.yaml
+++ b/task/sast-snyk-check-oci-ta/0.5/sast-snyk-check-oci-ta.yaml
@@ -299,7 +299,7 @@ spec:
         # The real exit code is always preserved in SNYK_EXIT_CODE.
         # Error codes (2+) always override, valid codes (0, 1, 3) only if no previous error.
         _snyk_code_test() {
-          snyk code test "$@" 1>&2 >>stdout.txt
+          snyk code test "$@" 1>&2 >>"${WORK_DIR}/stdout.txt"
           local ec=$?
           if [[ "$ec" -ne 0 ]] && [[ "$ec" -ne 1 ]] && [[ "$ec" -ne 3 ]]; then
             SNYK_EXIT_CODE=$ec
@@ -311,6 +311,7 @@ spec:
         }
 
         SNYK_EXIT_CODE=0
+        WORK_DIR="$(pwd)"
         SOURCE_CODE_DIR=/var/workdir/source
 
         # We ignore files using snyk ignore if the user set up the IGNORE_FILE_PATHS variable.
@@ -348,12 +349,58 @@ spec:
 
         done
 
-        # Merge all SARIF outputs
-        find "$SOURCE_CODE_DIR" -name "sast_snyk_check_out_*.json" -exec cat {} + >"${SOURCE_CODE_DIR}/sast_snyk_check_out.json"
+        # Merge all per-target SARIF outputs into a single valid SARIF file
+        shopt -s globstar nullglob
+        cd "${SOURCE_CODE_DIR}" || exit 1
+        if compgen -G "./**/sast_snyk_check_out_*.json" >/dev/null 2>&1; then
+          csgrep --mode=sarif ./**/sast_snyk_check_out_*.json >"${SOURCE_CODE_DIR}/sast_snyk_check_out.json" 2>/dev/null || {
+            echo "WARN: Failed to merge SARIF files with csgrep, creating empty SARIF"
+            SNYK_VERSION=$(snyk --version 2>/dev/null | head -1 | tr -d '\n' || echo "unknown")
+            jq -n --arg version "$SNYK_VERSION" '{
+              "$schema": "https://json.schemastore.org/sarif-2.1.0.json",
+              "version": "2.1.0",
+              "runs": [{
+                "tool": {
+                  "driver": {
+                    "name": "snyk",
+                    "version": $version,
+                    "informationUri": "https://snyk.io"
+                  }
+                },
+                "results": [],
+                "properties": {
+                  "coverage": []
+                }
+              }]
+            }' >"${SOURCE_CODE_DIR}/sast_snyk_check_out.json"
+          }
+        else
+          echo "WARN: No SARIF output files found, creating empty SARIF"
+          SNYK_VERSION=$(snyk --version 2>/dev/null | head -1 | tr -d '\n' || echo "unknown")
+          jq -n --arg version "$SNYK_VERSION" '{
+            "$schema": "https://json.schemastore.org/sarif-2.1.0.json",
+            "version": "2.1.0",
+            "runs": [{
+              "tool": {
+                "driver": {
+                  "name": "snyk",
+                  "version": $version,
+                  "informationUri": "https://snyk.io"
+                }
+              },
+              "results": [],
+              "properties": {
+                "coverage": []
+              }
+            }]
+          }' >"${SOURCE_CODE_DIR}/sast_snyk_check_out.json"
+        fi
+        shopt -u globstar nullglob
+        cd "${WORK_DIR}" || exit 1
         set -e
         test_not_skipped=0
         SKIP_MSG="We found 0 supported files"
-        grep -q "$SKIP_MSG" stdout.txt || test_not_skipped=$?
+        grep -q "$SKIP_MSG" "${WORK_DIR}/stdout.txt" || test_not_skipped=$?
 
         if [[ "$SNYK_EXIT_CODE" -eq 0 ]] || [[ "$SNYK_EXIT_CODE" -eq 1 ]]; then
           # Check if the merged SARIF file has content - this could happen if the snyk scan found no findings
@@ -382,9 +429,17 @@ spec:
             }' >"${SOURCE_CODE_DIR}/sast_snyk_check_out.json"
           fi
 
-          # In order to generate csdiff/v1, we need to add the whole path of the source code as Snyk only provides an URI to embed the context
-          (cd "${SOURCE_CODE_DIR}" && csgrep --mode=json --embed-context=3 "${SOURCE_CODE_DIR}"/sast_snyk_check_out.json) \
-            >sast_snyk_check_out_all_findings.json
+          # Build all_findings from per-target SARIF directly (csgrep JSON format for csfilter-kfp)
+          shopt -s globstar nullglob
+          cd "${SOURCE_CODE_DIR}" || exit 1
+          if compgen -G "./**/sast_snyk_check_out_*.json" >/dev/null 2>&1; then
+            csgrep --mode=json --embed-context=3 ./**/sast_snyk_check_out_*.json \
+              >"${WORK_DIR}/sast_snyk_check_out_all_findings.json"
+          else
+            echo '[]' >"${WORK_DIR}/sast_snyk_check_out_all_findings.json"
+          fi
+          shopt -u globstar nullglob
+          cd "${WORK_DIR}" || exit 1
 
           echo "INFO: Initial results:"
           csgrep --mode=evtstat sast_snyk_check_out_all_findings.json
@@ -397,7 +452,7 @@ spec:
           # create the KFP clone directory regardless
           KFP_DIR="known-false-positives"
           KFP_CLONED="0"
-          mkdir "${KFP_DIR}"
+          mkdir -p "${KFP_DIR}"
 
           # We check if the KFP_GIT_URL variable is set to clone and apply the filters or not
           if [[ -n "${KFP_GIT_URL}" ]]; then
@@ -410,7 +465,7 @@ spec:
           fi
 
           if [[ "${KFP_CLONED}" -eq "0" ]]; then
-            echo "WARN: Failed to clone know-false-positives at ${KFP_GIT_URL}, scan results will not be filtered"
+            echo "WARN: Failed to clone known-false-positives at ${KFP_GIT_URL}, scan results will not be filtered"
             mv sast_snyk_check_out_all_findings.json filtered_sast_snyk_check_out.json
           else
             echo "INFO: Filtering false positives in results files using csfilter-kfp..."
@@ -441,8 +496,8 @@ spec:
 
           # Generation of scan stats
 
-          total_files=$(jq '[.runs[0].properties.coverage[].files] | add' "${SOURCE_CODE_DIR}"/sast_snyk_check_out.json)
-          supported_files=$(jq '[.runs[0].properties.coverage[] | select(.type == "SUPPORTED") | .files] | add' "${SOURCE_CODE_DIR}"/sast_snyk_check_out.json)
+          total_files=$(jq '[(.runs[0].properties.coverage // [])[].files] | add' "${SOURCE_CODE_DIR}"/sast_snyk_check_out.json)
+          supported_files=$(jq '[(.runs[0].properties.coverage // [])[] | select(.type == "SUPPORTED") | .files] | add' "${SOURCE_CODE_DIR}"/sast_snyk_check_out.json)
 
           # We make sure the values are 0 if no supported/total files are found
           if [ "$total_files" = "null" ] || [ -z "$total_files" ]; then
@@ -486,7 +541,7 @@ spec:
           ERROR_OUTPUT=$(make_result_json -r SUCCESS -t "$note")
         else
           echo "sast-snyk-check test failed because of the following issues:"
-          cat stdout.txt
+          cat "${WORK_DIR}/stdout.txt"
           note="Task $(context.task.name) failed: For details, check Tekton task log."
           ERROR_OUTPUT=$(make_result_json -r ERROR -t "$note")
         fi
@@ -524,7 +579,7 @@ spec:
             echo "No ${UPLOAD_FILE} exists. Skipping upload."
             continue
           fi
-          if [ "${UPLOAD_FILES}" == "excluded-findings.json" ]; then
+          if [ "${UPLOAD_FILE}" == "excluded-findings.json" ]; then
             MEDIA_TYPE=application/json
           else
             MEDIA_TYPE=application/sarif+json

--- a/task/sast-snyk-check/0.5/sast-snyk-check.yaml
+++ b/task/sast-snyk-check/0.5/sast-snyk-check.yaml
@@ -175,7 +175,7 @@ spec:
         # The real exit code is always preserved in SNYK_EXIT_CODE.
         # Error codes (2+) always override, valid codes (0, 1, 3) only if no previous error.
         _snyk_code_test() {
-          snyk code test "$@" 1>&2>> stdout.txt
+          snyk code test "$@" 1>&2>> "${WORK_DIR}/stdout.txt"
           local ec=$?
           if [[ "$ec" -ne 0 ]] && [[ "$ec" -ne 1 ]] && [[ "$ec" -ne 3 ]]; then
             SNYK_EXIT_CODE=$ec
@@ -187,6 +187,7 @@ spec:
         }
 
         SNYK_EXIT_CODE=0
+        WORK_DIR="$(pwd)"
         SOURCE_CODE_DIR=$(workspaces.workspace.path)/source
 
         # We ignore files using snyk ignore if the user set up the IGNORE_FILE_PATHS variable.
@@ -224,12 +225,58 @@ spec:
 
         done
 
-        # Merge all SARIF outputs
-        find "$SOURCE_CODE_DIR" -name "sast_snyk_check_out_*.json" -exec cat {} + > "${SOURCE_CODE_DIR}/sast_snyk_check_out.json"
+        # Merge all per-target SARIF outputs into a single valid SARIF file
+        shopt -s globstar nullglob
+        cd "${SOURCE_CODE_DIR}" || exit 1
+        if compgen -G "./**/sast_snyk_check_out_*.json" >/dev/null 2>&1; then
+          csgrep --mode=sarif ./**/sast_snyk_check_out_*.json >"${SOURCE_CODE_DIR}/sast_snyk_check_out.json" 2>/dev/null || {
+            echo "WARN: Failed to merge SARIF files with csgrep, creating empty SARIF"
+            SNYK_VERSION=$(snyk --version 2>/dev/null | head -1 | tr -d '\n' || echo "unknown")
+            jq -n --arg version "$SNYK_VERSION" '{
+              "$schema": "https://json.schemastore.org/sarif-2.1.0.json",
+              "version": "2.1.0",
+              "runs": [{
+                "tool": {
+                  "driver": {
+                    "name": "snyk",
+                    "version": $version,
+                    "informationUri": "https://snyk.io"
+                  }
+                },
+                "results": [],
+                "properties": {
+                  "coverage": []
+                }
+              }]
+            }' >"${SOURCE_CODE_DIR}/sast_snyk_check_out.json"
+          }
+        else
+          echo "WARN: No SARIF output files found, creating empty SARIF"
+          SNYK_VERSION=$(snyk --version 2>/dev/null | head -1 | tr -d '\n' || echo "unknown")
+          jq -n --arg version "$SNYK_VERSION" '{
+            "$schema": "https://json.schemastore.org/sarif-2.1.0.json",
+            "version": "2.1.0",
+            "runs": [{
+              "tool": {
+                "driver": {
+                  "name": "snyk",
+                  "version": $version,
+                  "informationUri": "https://snyk.io"
+                }
+              },
+              "results": [],
+              "properties": {
+                "coverage": []
+              }
+            }]
+          }' >"${SOURCE_CODE_DIR}/sast_snyk_check_out.json"
+        fi
+        shopt -u globstar nullglob
+        cd "${WORK_DIR}" || exit 1
         set -e
         test_not_skipped=0
         SKIP_MSG="We found 0 supported files"
-        grep -q "$SKIP_MSG" stdout.txt || test_not_skipped=$?
+        grep -q "$SKIP_MSG" "${WORK_DIR}/stdout.txt" || test_not_skipped=$?
 
         if [[ "$SNYK_EXIT_CODE" -eq 0 ]] || [[ "$SNYK_EXIT_CODE" -eq 1 ]]; then
           # Check if the merged SARIF file has content - this could happen if the snyk scan found no findings
@@ -258,9 +305,17 @@ spec:
             }' >"${SOURCE_CODE_DIR}/sast_snyk_check_out.json"
           fi
 
-          # In order to generate csdiff/v1, we need to add the whole path of the source code as Snyk only provides an URI to embed the context
-          (cd  "${SOURCE_CODE_DIR}" && csgrep --mode=json --embed-context=3 "${SOURCE_CODE_DIR}"/sast_snyk_check_out.json) \
-            > sast_snyk_check_out_all_findings.json
+          # Build all_findings from per-target SARIF directly (csgrep JSON format for csfilter-kfp)
+          shopt -s globstar nullglob
+          cd "${SOURCE_CODE_DIR}" || exit 1
+          if compgen -G "./**/sast_snyk_check_out_*.json" >/dev/null 2>&1; then
+            csgrep --mode=json --embed-context=3 ./**/sast_snyk_check_out_*.json \
+              > "${WORK_DIR}/sast_snyk_check_out_all_findings.json"
+          else
+            echo '[]' > "${WORK_DIR}/sast_snyk_check_out_all_findings.json"
+          fi
+          shopt -u globstar nullglob
+          cd "${WORK_DIR}" || exit 1
 
           echo "INFO: Initial results:"
           csgrep --mode=evtstat sast_snyk_check_out_all_findings.json
@@ -273,7 +328,7 @@ spec:
           # create the KFP clone directory regardless
           KFP_DIR="known-false-positives"
           KFP_CLONED="0"
-          mkdir "${KFP_DIR}"
+          mkdir -p "${KFP_DIR}"
 
           # We check if the KFP_GIT_URL variable is set to clone and apply the filters or not
           if [[ -n "${KFP_GIT_URL}" ]]; then
@@ -286,7 +341,7 @@ spec:
           fi
 
           if [[ "${KFP_CLONED}" -eq "0" ]]; then
-            echo "WARN: Failed to clone know-false-positives at ${KFP_GIT_URL}, scan results will not be filtered"
+            echo "WARN: Failed to clone known-false-positives at ${KFP_GIT_URL}, scan results will not be filtered"
             mv sast_snyk_check_out_all_findings.json filtered_sast_snyk_check_out.json
           else
             echo "INFO: Filtering false positives in results files using csfilter-kfp..."
@@ -317,8 +372,8 @@ spec:
 
           # Generation of scan stats
 
-          total_files=$(jq '[.runs[0].properties.coverage[].files] | add' "${SOURCE_CODE_DIR}"/sast_snyk_check_out.json)
-          supported_files=$(jq '[.runs[0].properties.coverage[] | select(.type == "SUPPORTED") | .files] | add' "${SOURCE_CODE_DIR}"/sast_snyk_check_out.json)
+          total_files=$(jq '[(.runs[0].properties.coverage // [])[].files] | add' "${SOURCE_CODE_DIR}"/sast_snyk_check_out.json)
+          supported_files=$(jq '[(.runs[0].properties.coverage // [])[] | select(.type == "SUPPORTED") | .files] | add' "${SOURCE_CODE_DIR}"/sast_snyk_check_out.json)
 
           # We make sure the values are 0 if no supported/total files are found
           if [ "$total_files" = "null" ] || [ -z "$total_files" ]; then
@@ -362,7 +417,7 @@ spec:
           ERROR_OUTPUT=$(make_result_json -r SUCCESS -t "$note")
         else
           echo "sast-snyk-check test failed because of the following issues:"
-          cat stdout.txt
+          cat "${WORK_DIR}/stdout.txt"
           note="Task $(context.task.name) failed: For details, check Tekton task log."
           ERROR_OUTPUT=$(make_result_json -r ERROR -t "$note")
         fi
@@ -400,7 +455,7 @@ spec:
               echo "No ${UPLOAD_FILE} exists. Skipping upload."
               continue
             fi
-            if [ "${UPLOAD_FILES}" == "excluded-findings.json" ]; then
+            if [ "${UPLOAD_FILE}" == "excluded-findings.json" ]; then
                 MEDIA_TYPE=application/json
             else
                 MEDIA_TYPE=application/sarif+json

--- a/task/sast-snyk-check/0.5/tests/test-sast-snyk-check-target-dirs.yaml
+++ b/task/sast-snyk-check/0.5/tests/test-sast-snyk-check-target-dirs.yaml
@@ -5,8 +5,9 @@ metadata:
   name: test-sast-snyk-check-target-dirs
 spec:
   description: |
-    Test that sast-snyk-check resolves TARGET_DIRS relative to the source
-    checkout directory, not the workspace root.
+    Test that sast-snyk-check correctly merges SARIF output when TARGET_DIRS
+    contains multiple comma-separated directories. The finding is in the
+    middle directory (test-project) to prove the merge isn't first-or-last wins.
   workspaces:
     - name: tests-workspace
   tasks:
@@ -57,7 +58,7 @@ spec:
         - name: image-digest
           value: sha256:a6e305864fefbce727a3d8cc9f0277eede5f0617696f9cda486b1f6b3b94f7cb
         - name: TARGET_DIRS
-          value: "test-project"
+          value: "gcc,test-project,python-samples"
     - name: check-result
       runAfter:
         - scan-with-snyk
@@ -87,4 +88,6 @@ spec:
               echo "$RESULTS" | jq -e '.result == "FAILURE" and .successes == 0 and .failures == 1 and .warnings == 0'
 
               report=$(find . -name 'sast_snyk_check_out.sarif')
+              echo -n "Validating SARIF structure: "
+              jq -e '.version != null and (.runs | length) > 0' "$report"
               jq -e 'select(.inlineExternalProperties[0].externalizedProperties["analyzer-version-snyk-code"] != null)' "$report"


### PR DESCRIPTION
Replace broken find/cat SARIF concatenation with csgrep --mode=sarif merge. Fix jq null-safety, stdout.txt paths, mkdir -p, UPLOAD_FILE variable typo, and known-false-positives typo. Update target-dirs test to use three directories with finding in middle dir to validate merge correctness.


more info in [PSSECAUT-1385](https://redhat.atlassian.net/browse/PSSECAUT-1385)

[PSSECAUT-1385]: https://redhat.atlassian.net/browse/PSSECAUT-1385?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ