### PR TITLE
fix(PSSECAUT-1599): prepend target dir prefix to snyk SARIF paths

### DIFF
--- a/task/sast-snyk-check-oci-ta/0.5/sast-snyk-check-oci-ta.yaml
+++ b/task/sast-snyk-check-oci-ta/0.5/sast-snyk-check-oci-ta.yaml
@@ -369,6 +369,13 @@ spec:
           # shellcheck disable=SC2086
           RETRY_INTERVAL=30 retry _snyk_code_test $ARGS "$resolved_path" --max-depth=1 --sarif-file-output="${resolved_path}/sast_snyk_check_out_${d//\//_}.json"
 
+          sarif_out="${resolved_path}/sast_snyk_check_out_${d//\//_}.json"
+          if [[ "$d" != "." && -f "$sarif_out" ]]; then
+            prefix="${d%/}/"
+            echo "INFO: Prepending path prefix '${prefix}' to ${sarif_out}"
+            csgrep --mode=sarif --prepend-path-prefix="$prefix" "$sarif_out" >"${sarif_out}.tmp" && mv "${sarif_out}.tmp" "$sarif_out"
+          fi
+
         done
 
         # Merge all per-target SARIF outputs into a single valid SARIF file

--- a/task/sast-snyk-check/0.5/sast-snyk-check.yaml
+++ b/task/sast-snyk-check/0.5/sast-snyk-check.yaml
@@ -245,6 +245,13 @@ spec:
           # shellcheck disable=SC2086
           RETRY_INTERVAL=30 retry _snyk_code_test $ARGS "$resolved_path" --max-depth=1 --sarif-file-output="${resolved_path}/sast_snyk_check_out_${d//\//_}.json"
 
+          sarif_out="${resolved_path}/sast_snyk_check_out_${d//\//_}.json"
+          if [[ "$d" != "." && -f "$sarif_out" ]]; then
+            prefix="${d%/}/"
+            echo "INFO: Prepending path prefix '${prefix}' to ${sarif_out}"
+            csgrep --mode=sarif --prepend-path-prefix="$prefix" "$sarif_out" > "${sarif_out}.tmp" && mv "${sarif_out}.tmp" "$sarif_out"
+          fi
+
         done
 
         # Merge all per-target SARIF outputs into a single valid SARIF file

--- a/task/sast-snyk-check/0.5/tests/test-sast-snyk-check-target-dirs.yaml
+++ b/task/sast-snyk-check/0.5/tests/test-sast-snyk-check-target-dirs.yaml
@@ -91,3 +91,6 @@ spec:
               echo -n "Validating SARIF structure: "
               jq -e '.version != null and (.runs | length) > 0' "$report"
               jq -e 'select(.inlineExternalProperties[0].externalizedProperties["analyzer-version-snyk-code"] != null)' "$report"
+
+              echo -n "Checking path prefix in findings: "
+              jq -e '.runs[0].results[0].locations[0].physicalLocation.artifactLocation.uri | startswith("test-project/")' "$report"


### PR DESCRIPTION
When TARGET_DIRS contains multiple directories, snyk outputs file paths
relative to each target directory. This makes findings ambiguous after
merging — e.g. `features/cve/audit.py` could be from `tests/` or
`evals/`. Use `csgrep --prepend-path-prefix` on each per-target SARIF
file before merging so paths include the target directory prefix.

Other SAST tasks (shell-check, unicode-check, gitleaks, coverity) were
investigated and are not affected — they either pass absolute paths with
strip-path-prefix normalization, or run from the source root directly.