### PR TITLE
chore: remove broken symlinks

### DIFF
--- a/task/coverity-availability-check/0.1
+++ b/task/coverity-availability-check/0.1
@@ -1,1 +1,0 @@
-../../archived-tasks/coverity-availability-check/0.1

--- a/task/sast-coverity-check-oci-ta/0.1
+++ b/task/sast-coverity-check-oci-ta/0.1
@@ -1,1 +1,0 @@
-../../archived-tasks/sast-coverity-check-oci-ta/0.1

--- a/task/sast-coverity-check-oci-ta/0.2
+++ b/task/sast-coverity-check-oci-ta/0.2
@@ -1,1 +1,0 @@
-../../archived-tasks/sast-coverity-check-oci-ta/0.2

--- a/task/sast-coverity-check/0.1
+++ b/task/sast-coverity-check/0.1
@@ -1,1 +1,0 @@
-../../archived-tasks/sast-coverity-check/0.1

--- a/task/sast-coverity-check/0.2
+++ b/task/sast-coverity-check/0.2
@@ -1,1 +1,0 @@
-../../archived-tasks/sast-coverity-check/0.2

--- a/task/sast-snyk-check-oci-ta/0.1
+++ b/task/sast-snyk-check-oci-ta/0.1
@@ -1,1 +1,0 @@
-../../archived-tasks/sast-snyk-check-oci-ta/0.1

--- a/task/sast-snyk-check-oci-ta/0.2
+++ b/task/sast-snyk-check-oci-ta/0.2
@@ -1,1 +1,0 @@
-../../archived-tasks/sast-snyk-check-oci-ta/0.2

--- a/task/sast-snyk-check-oci-ta/0.3
+++ b/task/sast-snyk-check-oci-ta/0.3
@@ -1,1 +1,0 @@
-../../archived-tasks/sast-snyk-check-oci-ta/0.3

--- a/task/sast-snyk-check/0.1
+++ b/task/sast-snyk-check/0.1
@@ -1,1 +1,0 @@
-../../archived-tasks/sast-snyk-check/0.1

--- a/task/sast-snyk-check/0.2
+++ b/task/sast-snyk-check/0.2
@@ -1,1 +1,0 @@
-../../archived-tasks/sast-snyk-check/0.2

--- a/task/sast-snyk-check/0.3
+++ b/task/sast-snyk-check/0.3
@@ -1,1 +1,0 @@
-../../archived-tasks/sast-snyk-check/0.3

--- a/task/sast-unicode-check-oci-ta/0.1
+++ b/task/sast-unicode-check-oci-ta/0.1
@@ -1,1 +1,0 @@
-../../archived-tasks/sast-unicode-check-oci-ta/0.1

--- a/task/sast-unicode-check/0.1
+++ b/task/sast-unicode-check/0.1
@@ -1,1 +1,0 @@
-../../archived-tasks/sast-unicode-check/0.1


### PR DESCRIPTION
These are leftovers from migration from konflux-ci/build-definitions repo.