### PR TITLE
chore(tests): use init task bundle instead of git resolver

### DIFF
--- a/task/sast-gitleaks-check/0.1/tests/test-sast-gitleaks-check-fail.yaml
+++ b/task/sast-gitleaks-check/0.1/tests/test-sast-gitleaks-check-fail.yaml
@@ -11,14 +11,14 @@ spec:
   tasks:
     - name: init
       taskRef:
-        resolver: git
+        resolver: bundles
         params:
-          - name: url
-            value: https://github.com/konflux-ci/build-definitions.git
-          - name: revision
-            value: main
-          - name: pathInRepo
-            value: task/init/0.2/init.yaml
+          - name: name
+            value: init
+          - name: bundle
+            value: quay.io/konflux-ci/tekton-catalog/task-init:0.4@sha256:5a423246792ac501ea279229b42ee57da9927da441c04b5c9ff86817b0856b08
+          - name: kind
+            value: task
       params:
         - name: image-url
           value: "quay.io/redhat-user-workloads/sast-tests-tenant/tests/tests-sast-shell-check:latest"

--- a/task/sast-shell-check/0.1/tests/test-sast-shell-check-bad-kfp-repo.yaml
+++ b/task/sast-shell-check/0.1/tests/test-sast-shell-check-bad-kfp-repo.yaml
@@ -11,14 +11,14 @@ spec:
   tasks:
     - name: init
       taskRef:
-        resolver: git
+        resolver: bundles
         params:
-          - name: url
-            value: https://github.com/konflux-ci/build-definitions.git
-          - name: revision
-            value: main
-          - name: pathInRepo
-            value: task/init/0.2/init.yaml
+          - name: name
+            value: init
+          - name: bundle
+            value: quay.io/konflux-ci/tekton-catalog/task-init:0.4@sha256:5a423246792ac501ea279229b42ee57da9927da441c04b5c9ff86817b0856b08
+          - name: kind
+            value: task
       params:
         - name: image-url
           value: "quay.io/redhat-user-workloads/sast-tests-tenant/tests/tests-sast-shell-check:latest"

--- a/task/sast-shell-check/0.1/tests/test-sast-shell-check-negative.yaml
+++ b/task/sast-shell-check/0.1/tests/test-sast-shell-check-negative.yaml
@@ -13,14 +13,14 @@ spec:
   tasks:
     - name: init
       taskRef:
-        resolver: git
+        resolver: bundles
         params:
-          - name: url
-            value: https://github.com/konflux-ci/build-definitions.git
-          - name: revision
-            value: main
-          - name: pathInRepo
-            value: task/init/0.2/init.yaml
+          - name: name
+            value: init
+          - name: bundle
+            value: quay.io/konflux-ci/tekton-catalog/task-init:0.4@sha256:5a423246792ac501ea279229b42ee57da9927da441c04b5c9ff86817b0856b08
+          - name: kind
+            value: task
       params:
         - name: image-url
           value: "quay.io/redhat-user-workloads/sast-tests-tenant/tests/tests-sast-shell-check:latest"

--- a/task/sast-shell-check/0.1/tests/test-sast-shell-check.yaml
+++ b/task/sast-shell-check/0.1/tests/test-sast-shell-check.yaml
@@ -11,14 +11,14 @@ spec:
   tasks:
     - name: init
       taskRef:
-        resolver: git
+        resolver: bundles
         params:
-          - name: url
-            value: https://github.com/konflux-ci/build-definitions.git
-          - name: revision
-            value: main
-          - name: pathInRepo
-            value: task/init/0.2/init.yaml
+          - name: name
+            value: init
+          - name: bundle
+            value: quay.io/konflux-ci/tekton-catalog/task-init:0.4@sha256:5a423246792ac501ea279229b42ee57da9927da441c04b5c9ff86817b0856b08
+          - name: kind
+            value: task
       params:
         - name: image-url
           value: "quay.io/redhat-user-workloads/sast-tests-tenant/tests/tests-sast-shell-check:latest"

--- a/task/sast-snyk-check-oci-ta/0.5/tests/test-sast-snyk-check-oci-ta.yaml
+++ b/task/sast-snyk-check-oci-ta/0.5/tests/test-sast-snyk-check-oci-ta.yaml
@@ -13,14 +13,14 @@ spec:
   tasks:
     - name: init
       taskRef:
-        resolver: git
+        resolver: bundles
         params:
-          - name: url
-            value: https://github.com/konflux-ci/build-definitions.git
-          - name: revision
-            value: main
-          - name: pathInRepo
-            value: task/init/0.2/init.yaml
+          - name: name
+            value: init
+          - name: bundle
+            value: quay.io/konflux-ci/tekton-catalog/task-init:0.4@sha256:5a423246792ac501ea279229b42ee57da9927da441c04b5c9ff86817b0856b08
+          - name: kind
+            value: task
       params:
         - name: image-url
           value: "quay.io/redhat-user-workloads/sast-tests-tenant/tests/tests-sast-shell-check:latest"

--- a/task/sast-snyk-check/0.5/tests/test-sast-snyk-check-target-dirs.yaml
+++ b/task/sast-snyk-check/0.5/tests/test-sast-snyk-check-target-dirs.yaml
@@ -13,14 +13,14 @@ spec:
   tasks:
     - name: init
       taskRef:
-        resolver: git
+        resolver: bundles
         params:
-          - name: url
-            value: https://github.com/konflux-ci/build-definitions.git
-          - name: revision
-            value: main
-          - name: pathInRepo
-            value: task/init/0.2/init.yaml
+          - name: name
+            value: init
+          - name: bundle
+            value: quay.io/konflux-ci/tekton-catalog/task-init:0.4@sha256:5a423246792ac501ea279229b42ee57da9927da441c04b5c9ff86817b0856b08
+          - name: kind
+            value: task
       params:
         - name: image-url
           value: "quay.io/redhat-user-workloads/sast-tests-tenant/tests/tests-sast-shell-check:latest"

--- a/task/sast-snyk-check/0.5/tests/test-sast-snyk-check.yaml
+++ b/task/sast-snyk-check/0.5/tests/test-sast-snyk-check.yaml
@@ -11,14 +11,14 @@ spec:
   tasks:
     - name: init
       taskRef:
-        resolver: git
+        resolver: bundles
         params:
-          - name: url
-            value: https://github.com/konflux-ci/build-definitions.git
-          - name: revision
-            value: main
-          - name: pathInRepo
-            value: task/init/0.2/init.yaml
+          - name: name
+            value: init
+          - name: bundle
+            value: quay.io/konflux-ci/tekton-catalog/task-init:0.4@sha256:5a423246792ac501ea279229b42ee57da9927da441c04b5c9ff86817b0856b08
+          - name: kind
+            value: task
       params:
         - name: image-url
           value: "quay.io/redhat-user-workloads/sast-tests-tenant/tests/tests-sast-shell-check:latest"

--- a/task/sast-unicode-check/0.4/tests/test-sast-unicode-check-bad-kfp-repo.yaml
+++ b/task/sast-unicode-check/0.4/tests/test-sast-unicode-check-bad-kfp-repo.yaml
@@ -11,14 +11,14 @@ spec:
   tasks:
     - name: init
       taskRef:
-        resolver: git
+        resolver: bundles
         params:
-          - name: url
-            value: https://github.com/konflux-ci/build-definitions.git
-          - name: revision
-            value: main
-          - name: pathInRepo
-            value: task/init/0.2/init.yaml
+          - name: name
+            value: init
+          - name: bundle
+            value: quay.io/konflux-ci/tekton-catalog/task-init:0.4@sha256:5a423246792ac501ea279229b42ee57da9927da441c04b5c9ff86817b0856b08
+          - name: kind
+            value: task
       params:
         - name: image-url
           value: "quay.io/redhat-user-workloads/sast-tests-tenant/tests/tests-sast-unicode-check:latest"

--- a/task/sast-unicode-check/0.4/tests/test-sast-unicode-check.yaml
+++ b/task/sast-unicode-check/0.4/tests/test-sast-unicode-check.yaml
@@ -11,14 +11,14 @@ spec:
   tasks:
     - name: init
       taskRef:
-        resolver: git
+        resolver: bundles
         params:
-          - name: url
-            value: https://github.com/konflux-ci/build-definitions.git
-          - name: revision
-            value: main
-          - name: pathInRepo
-            value: task/init/0.2/init.yaml
+          - name: name
+            value: init
+          - name: bundle
+            value: quay.io/konflux-ci/tekton-catalog/task-init:0.4@sha256:5a423246792ac501ea279229b42ee57da9927da441c04b5c9ff86817b0856b08
+          - name: kind
+            value: task
       params:
         - name: image-url
           value: "quay.io/redhat-user-workloads/sast-tests-tenant/tests/tests-sast-unicode-check:latest"


### PR DESCRIPTION
Switch test pipelines from resolving the init task via the build-definitions git repo to using the external task bundle, matching the approach already used in .tekton/ CI pipelines.