### PR TITLE
fix(ci): update konflux-ci/konflux-ci ref to fix CI deployment

### DIFF
--- a/.github/workflows/run-task-tests.yaml
+++ b/.github/workflows/run-task-tests.yaml
@@ -62,7 +62,7 @@ jobs:
         with:
           repository: 'konflux-ci/konflux-ci'
           path: konflux-ci
-          ref: bc8721b778592cbf3f18ca025e351ebd7f2eb399
+          ref: 3a694f8d7b49e74f476bb9414fc3e6d03d50ae37
 
       - name: Create k8s Kind Cluster
         if: steps.tasks-to-be-tested.outputs.tasklist != ''


### PR DESCRIPTION
The previous ref (bc8721b) references a release-service image (411e8fa...) that no longer exists on quay.io, causing ImagePullBackOff and deployment timeout in all PR CI runs.