### PR TITLE
fix(ci): update git-clone task refs to build-pipeline-tasks repo

### DIFF
--- a/task/sast-gitleaks-check/0.1/tests/test-sast-gitleaks-check-fail.yaml
+++ b/task/sast-gitleaks-check/0.1/tests/test-sast-gitleaks-check-fail.yaml
@@ -37,11 +37,11 @@ spec:
         resolver: git
         params:
           - name: url
-            value: https://github.com/konflux-ci/build-definitions.git
+            value: https://github.com/konflux-ci/build-pipeline-tasks.git
           - name: revision
             value: main
           - name: pathInRepo
-            value: task/git-clone/0.1/git-clone.yaml
+            value: task/git-clone/git-clone.yaml
     - name: scan-with-gitleaks
       runAfter:
         - clone-repository

--- a/task/sast-shell-check/0.1/tests/test-sast-shell-check-bad-kfp-repo.yaml
+++ b/task/sast-shell-check/0.1/tests/test-sast-shell-check-bad-kfp-repo.yaml
@@ -37,11 +37,11 @@ spec:
         resolver: git
         params:
           - name: url
-            value: https://github.com/konflux-ci/build-definitions.git
+            value: https://github.com/konflux-ci/build-pipeline-tasks.git
           - name: revision
             value: main
           - name: pathInRepo
-            value: task/git-clone/0.1/git-clone.yaml
+            value: task/git-clone/git-clone.yaml
     - name: scan-with-shellcheck
       workspaces:
         - name: workspace

--- a/task/sast-shell-check/0.1/tests/test-sast-shell-check.yaml
+++ b/task/sast-shell-check/0.1/tests/test-sast-shell-check.yaml
@@ -37,11 +37,11 @@ spec:
         resolver: git
         params:
           - name: url
-            value: https://github.com/konflux-ci/build-definitions.git
+            value: https://github.com/konflux-ci/build-pipeline-tasks.git
           - name: revision
             value: main
           - name: pathInRepo
-            value: task/git-clone/0.1/git-clone.yaml
+            value: task/git-clone/git-clone.yaml
     - name: scan-with-shellcheck
       workspaces:
         - name: workspace

--- a/task/sast-snyk-check-oci-ta/0.5/tests/test-sast-snyk-check-oci-ta.yaml
+++ b/task/sast-snyk-check-oci-ta/0.5/tests/test-sast-snyk-check-oci-ta.yaml
@@ -38,11 +38,11 @@ spec:
         resolver: git
         params:
           - name: url
-            value: https://github.com/konflux-ci/build-definitions.git
+            value: https://github.com/konflux-ci/build-pipeline-tasks.git
           - name: revision
             value: main
           - name: pathInRepo
-            value: task/git-clone-oci-ta/0.1/git-clone-oci-ta.yaml
+            value: task/git-clone-oci-ta/git-clone-oci-ta.yaml
     - name: scan-with-snyk
       runAfter:
         - clone-repository

--- a/task/sast-snyk-check/0.5/tests/test-sast-snyk-check-retry.yaml
+++ b/task/sast-snyk-check/0.5/tests/test-sast-snyk-check-retry.yaml
@@ -23,11 +23,11 @@ spec:
         resolver: git
         params:
           - name: url
-            value: https://github.com/konflux-ci/build-definitions.git
+            value: https://github.com/konflux-ci/build-pipeline-tasks.git
           - name: revision
             value: main
           - name: pathInRepo
-            value: task/git-clone/0.1/git-clone.yaml
+            value: task/git-clone/git-clone.yaml
     - name: scan-with-snyk
       runAfter:
         - clone-repository

--- a/task/sast-snyk-check/0.5/tests/test-sast-snyk-check-target-dirs.yaml
+++ b/task/sast-snyk-check/0.5/tests/test-sast-snyk-check-target-dirs.yaml
@@ -39,11 +39,11 @@ spec:
         resolver: git
         params:
           - name: url
-            value: https://github.com/konflux-ci/build-definitions.git
+            value: https://github.com/konflux-ci/build-pipeline-tasks.git
           - name: revision
             value: main
           - name: pathInRepo
-            value: task/git-clone/0.1/git-clone.yaml
+            value: task/git-clone/git-clone.yaml
     - name: scan-with-snyk
       runAfter:
         - clone-repository

--- a/task/sast-snyk-check/0.5/tests/test-sast-snyk-check.yaml
+++ b/task/sast-snyk-check/0.5/tests/test-sast-snyk-check.yaml
@@ -37,11 +37,11 @@ spec:
         resolver: git
         params:
           - name: url
-            value: https://github.com/konflux-ci/build-definitions.git
+            value: https://github.com/konflux-ci/build-pipeline-tasks.git
           - name: revision
             value: main
           - name: pathInRepo
-            value: task/git-clone/0.1/git-clone.yaml
+            value: task/git-clone/git-clone.yaml
     - name: scan-with-snyk
       runAfter:
         - clone-repository

--- a/task/sast-unicode-check/0.4/tests/test-sast-unicode-check-bad-kfp-repo.yaml
+++ b/task/sast-unicode-check/0.4/tests/test-sast-unicode-check-bad-kfp-repo.yaml
@@ -39,11 +39,11 @@ spec:
         resolver: git
         params:
           - name: url
-            value: https://github.com/konflux-ci/build-definitions.git
+            value: https://github.com/konflux-ci/build-pipeline-tasks.git
           - name: revision
             value: main
           - name: pathInRepo
-            value: task/git-clone/0.1/git-clone.yaml
+            value: task/git-clone/git-clone.yaml
     - name: scan-with-unicode
       workspaces:
         - name: workspace

--- a/task/sast-unicode-check/0.4/tests/test-sast-unicode-check.yaml
+++ b/task/sast-unicode-check/0.4/tests/test-sast-unicode-check.yaml
@@ -39,11 +39,11 @@ spec:
         resolver: git
         params:
           - name: url
-            value: https://github.com/konflux-ci/build-definitions.git
+            value: https://github.com/konflux-ci/build-pipeline-tasks.git
           - name: revision
             value: main
           - name: pathInRepo
-            value: task/git-clone/0.1/git-clone.yaml
+            value: task/git-clone/git-clone.yaml
     - name: scan-with-unicode
       workspaces:
         - name: workspace


### PR DESCRIPTION
git-clone tasks were moved from build-definitions to build-pipeline-tasks (konflux-ci/build-definitions@306c1c80f).