### PR TITLE
fix(ci): align CI workflows with shared CI template

### DIFF
--- a/.github/workflows/check-task-migration.yaml
+++ b/.github/workflows/check-task-migration.yaml
@@ -1,3 +1,10 @@
+# yamllint disable-file
+
+# <TEMPLATED FILE!>
+# This file comes from the templates at https://github.com/konflux-ci/task-repo-shared-ci.
+# Please consider sending a PR upstream instead of editing the file directly.
+# See the SHARED-CI.md document in this repo for more details.
+
 name: Check task migrations
 "on":
   pull_request:
@@ -9,16 +16,16 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
           fetch-depth: 0
       - name: Create k8s Kind Cluster
-        uses: helm/kind-action@v1.12.0
+        uses: helm/kind-action@92086f6be054225fa813e0a4b13787fc9088faab # v1.13.0
         with:
           cluster_name: kind
       - uses: tektoncd/actions/setup-tektoncd@main
         with:
-          pipeline_version: latest
+          pipeline_version: v1.12.2
       - name: Run check
         run: |
           DEBIAN_FRONTEND=noninteractive \

--- a/.github/workflows/check-task-yamls.yaml
+++ b/.github/workflows/check-task-yamls.yaml
@@ -12,19 +12,19 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
           fetch-depth: 0
 
       - name: Create k8s Kind Cluster
-        uses: helm/kind-action@v1.12.0
+        uses: helm/kind-action@92086f6be054225fa813e0a4b13787fc9088faab # v1.13.0
         with:
           cluster_name: kind
 
       - name: Set up Tekton
         uses: tektoncd/actions/setup-tektoncd@main
         with:
-          pipeline_version: latest
+          pipeline_version: v1.12.2
 
       - name: Apply all Task YAMLs
         run: |

--- a/task/sast-shell-check/0.1/sast-shell-check.yaml
+++ b/task/sast-shell-check/0.1/sast-shell-check.yaml
@@ -9,7 +9,7 @@ metadata:
   name: sast-shell-check
 spec:
   description: >-
-    The sast-shell-check task uses [shellcheck](https://www.shellcheck.net/) tool to perform Static Application Security Testing (SAST), a popular cloud-native application security platform. This task leverages the shellcheck wrapper (csmock-plugin-shellcheck-core) to run shellcheck on a directory tree.
+    The sast-shell-check task uses [shellcheck](https://www.shellcheck.net/) tool to perform Static Application Security Testing (SAST). This task leverages the shellcheck wrapper (csmock-plugin-shellcheck-core) to run shellcheck on a directory tree.
 
     ShellCheck is a static analysis tool, gives warnings and suggestions for bash/sh shell scripts. This task can run on x86 and arm.
   results:


### PR DESCRIPTION
Add continue-on-error and failure description step for tektoncd/actions/setup-tektoncd to handle known upstream failures gracefully. Pin action SHAs and add pipeline-migration-tool install, matching the konflux-ci/task-repo-shared-ci template.