### PR TITLE
feat(sast-snyk-check-oci-ta): extract titled layers from container images

### DIFF
--- a/hack/generate-ta-tasks.sh
+++ b/hack/generate-ta-tasks.sh
@@ -22,6 +22,42 @@ tash() {
   "${tashbin}" "$@"
 }
 
+# Keep additionalSteps[].script in recipe.yaml identical to a sibling
+# fetch-extra-artifacts.sh when that file exists (unit-tested helper).
+sync_fetch_extra_artifacts_script() {
+  local recipe_path="$1"
+  local script_path="$2"
+  python3 - "${recipe_path}" "${script_path}" <<'PY'
+from pathlib import Path
+import sys
+
+recipe_path, script_path = Path(sys.argv[1]), Path(sys.argv[2])
+script = script_path.read_text()
+if not script.endswith("\n"):
+    script += "\n"
+indented = "".join(
+    "\n" if line == "\n" else f"      {line}"
+    for line in script.splitlines(keepends=True)
+)
+text = recipe_path.read_text()
+marker = "    name: fetch-extra-artifacts\n"
+start = text.find(marker)
+if start < 0:
+    sys.exit(f"ERROR: {recipe_path}: fetch-extra-artifacts step not found")
+key = "    script: |\n"
+sidx = text.find(key, start)
+if sidx < 0:
+    sys.exit(f"ERROR: {recipe_path}: script: | not found under fetch-extra-artifacts")
+body = sidx + len(key)
+end = text.find("\n    computeResources:", body)
+if end < 0:
+    sys.exit(f"ERROR: {recipe_path}: computeResources after script not found")
+updated = text[:body] + indented + text[end + 1 :]
+if updated != text:
+    recipe_path.write_text(updated)
+PY
+}
+
 declare -i changes=0
 emit() {
   if [ "${GITHUB_ACTIONS:-false}" == "true" ]; then
@@ -42,6 +78,10 @@ fi
 cd "${TASK_DIR}"
 for recipe_path in **/recipe.yaml; do
     task_path="${recipe_path%/recipe.yaml}/$(basename "${recipe_path%/*/*}").yaml"
+    script_src="${recipe_path%/recipe.yaml}/fetch-extra-artifacts.sh"
+    if [[ -f "${script_src}" ]]; then
+        sync_fetch_extra_artifacts_script "${TASK_DIR}/${recipe_path}" "${TASK_DIR}/${script_src}"
+    fi
     sponge=$(tash "${TASK_DIR}/${recipe_path}")
     echo "${sponge}" > "${task_path}"
     readme_path="${recipe_path%/recipe.yaml}/README.md"
@@ -51,6 +91,9 @@ for recipe_path in **/recipe.yaml; do
     fi
     if ! git diff --quiet HEAD "${readme_path}"; then
         emit "task/${readme_path}" "${msg}"
+    fi
+    if [[ -f "${script_src}" ]] && ! git diff --quiet HEAD "${recipe_path}"; then
+        emit "task/${recipe_path}" "${msg}"
     fi
 done
 

--- a/task/sast-snyk-check-oci-ta/0.5/MIGRATION.md
+++ b/task/sast-snyk-check-oci-ta/0.5/MIGRATION.md
@@ -10,3 +10,22 @@ Version 0.5:
 
 - Scan results may appear in different projects in the Snyk UI since the `--project-name` is now set by default.
 - Default value of `--project-name` is the value of the `PROJECT_NAME` parameter, which if unset, defaults to the name of the Konflux component (`appstudio.openshift.io/component` label).
+
+## FETCH_EXTRA_ARTIFACTS and container images (ModelCar)
+
+When `FETCH_EXTRA_ARTIFACTS=true`:
+
+- **OCI artifacts** (unchanged): fetch raw blobs whose `org.opencontainers.image.title` matches `EXTRA_ARTIFACT_FILTER`.
+- **Container images** (new): no longer skipped. For layers with a title annotation (e.g. ModelCar/olot layers), matching layers are blob-fetched and untarred into `/var/workdir/source`. Base-image layers without titles and non-matching weight blobs are not pulled.
+- **Image indexes**: multi-arch indexes are resolved to a single linux/amd64 (else first linux) manifest before layer extraction.
+
+To scan ModelCar model metadata files (not weights), set e.g.:
+
+```yaml
+- name: FETCH_EXTRA_ARTIFACTS
+  value: "true"
+- name: EXTRA_ARTIFACT_FILTER
+  value: '(^|/)(Dockerfile|Containerfile|[^/]+\.(json|jinja|py|rb|pl|js|mjs|cjs|ts|ps1|sh|bash|zsh|ksh|md|yaml|yml|txt|model))$'
+- name: TARGET_DIRS
+  value: models
+```

--- a/task/sast-snyk-check-oci-ta/0.5/README.md
+++ b/task/sast-snyk-check-oci-ta/0.5/README.md
@@ -12,8 +12,8 @@ See https://snyk.io/product/snyk-code/ and https://snyk.io/ for more information
 |name|description|default value|required|
 |---|---|---|---|
 |ARGS|Append arguments.|""|false|
-|EXTRA_ARTIFACT_FILTER|Extended regex matching org.opencontainers.image.title paths in the OCI manifest when FETCH_EXTRA_ARTIFACTS=true.|(^|/)(Dockerfile|Containerfile|[^/]+\.(sh|bash|zsh|ksh|py|rb|pl|js|mjs|cjs|ts|ps1))$|false|
-|FETCH_EXTRA_ARTIFACTS|When "true", fetch script-like files from image-url@image-digest (OCI artifact manifest) into /var/workdir/source alongside the restored SOURCE_ARTIFACT. Skipped for standard container images.|false|false|
+|EXTRA_ARTIFACT_FILTER|Extended regex matched against org.opencontainers.image.title (and olot.layer.content.inlayerpath when present) when FETCH_EXTRA_ARTIFACTS=true.|(^|/)(Dockerfile|Containerfile|[^/]+\.(sh|bash|zsh|ksh|py|rb|pl|js|mjs|cjs|ts|ps1))$|false|
+|FETCH_EXTRA_ARTIFACTS|When "true", fetch files matching EXTRA_ARTIFACT_FILTER from image-url@image-digest into /var/workdir/source alongside the restored SOURCE_ARTIFACT. Supports OCI artifacts (raw titled blobs) and container images with titled layers (e.g. ModelCar/olot), extracting matching tar layers without unpacking the full image.|false|false|
 |IGNORE_FILE_PATHS|Directories or files to be excluded from Snyk scan (Comma-separated). Useful to split the directories of a git repo across multiple components.|""|false|
 |IMP_FINDINGS_ONLY|Report only important findings in task result. Default is "true". To report all findings in task result, specify "false". Uploaded SARIF report to remote registry always includes all findings, regardless of severity level.|true|false|
 |KFP_GIT_URL|Known False Positives (KFP) git URL (optionally taking a revision delimited by \#). Defaults to "SITE_DEFAULT", which means the default value "https://gitlab.cee.redhat.com/osh/known-false-positives.git" for internal Konflux instance and empty string for external Konflux instance. If set to an empty string, the KFP filtering is disabled.|SITE_DEFAULT|false|

--- a/task/sast-snyk-check-oci-ta/0.5/fetch-extra-artifacts.sh
+++ b/task/sast-snyk-check-oci-ta/0.5/fetch-extra-artifacts.sh
@@ -1,0 +1,187 @@
+#!/usr/bin/env bash
+# Fetch files matching EXTRA_ARTIFACT_FILTER from image-url@image-digest into SOURCE_ROOT.
+# Used by sast-snyk-check-oci-ta fetch-extra-artifacts. Source this file to unit-test helpers.
+set -euo pipefail
+
+SOURCE_ROOT="${SOURCE_ROOT:-/var/workdir/source}"
+MANIFEST_FILE="${MANIFEST_FILE:-/tmp/manifest.json}"
+SELECT_OCI_AUTH="${SELECT_OCI_AUTH:-/usr/local/bin/select-oci-auth.sh}"
+ORAS_OPTS_FILE="${ORAS_OPTS_FILE:-/usr/local/bin/oras_opts.sh}"
+
+is_image_index() {
+  local media_type="$1"
+  [[ "${media_type}" == "application/vnd.oci.image.index.v1+json" ]] ||
+    [[ "${media_type}" == "application/vnd.docker.distribution.manifest.list.v2+json" ]]
+}
+
+is_container_image_config() {
+  local config_media_type="$1"
+  [[ "${config_media_type}" == "application/vnd.oci.image.config.v1+json" ]] ||
+    [[ "${config_media_type}" == "application/vnd.docker.container.image.v1+json" ]]
+}
+
+resolve_index_child_digest() {
+  local manifest_file="$1"
+  jq -r '
+    (.manifests // []) as $m
+    | ($m | map(select(.platform.architecture == "amd64" and ((.platform.os // "linux") == "linux"))) | .[0].digest)
+      // ($m | map(select((.platform.os // "linux") == "linux")) | .[0].digest)
+      // ($m[0].digest)
+      // empty
+  ' "${manifest_file}"
+}
+
+matches_filter() {
+  local match_path="$1"
+  local title="$2"
+  local filter="$3"
+  printf '%s\n' "${match_path}" | grep -Eq "${filter}" && return 0
+  printf '%s\n' "${title}" | grep -Eq "${filter}" && return 0
+  return 1
+}
+
+path_allowed() {
+  local rel_path="$1"
+  local resolved_dest
+  resolved_dest="$(realpath -m "${SOURCE_ROOT}/${rel_path}")"
+  if [[ ! "${resolved_dest}" == "${SOURCE_ROOT}"/* ]]; then
+    echo "WARN: Skipping path outside source root: ${rel_path}" >&2
+    return 1
+  fi
+  printf '%s\n' "${resolved_dest}"
+}
+
+extract_tarball() {
+  local blob="$1"
+  local dest="$2"
+  local media_type="$3"
+  if [[ "${media_type}" == *gzip* ]] || [[ "${media_type}" == *tar+gzip* ]]; then
+    tar -xzf "${blob}" -C "${dest}"
+  else
+    tar -xf "${blob}" -C "${dest}"
+  fi
+}
+
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+  if [[ "${FETCH_EXTRA_ARTIFACTS}" != "true" ]]; then
+    exit 0
+  fi
+
+  if [[ -z "${IMAGE_URL}" || -z "${IMAGE_DIGEST}" ]]; then
+    echo "INFO: image-url/image-digest missing, cannot fetch extra artifacts"
+    exit 0
+  fi
+
+  declare -a oras_opts=()
+  if [[ -f "${ORAS_OPTS_FILE}" ]]; then
+    # shellcheck source=/dev/null
+    source "${ORAS_OPTS_FILE}"
+  fi
+
+  IMAGE_REF="${IMAGE_URL}@${IMAGE_DIGEST}"
+  echo "INFO: Fetching extra artifacts from OCI reference ${IMAGE_REF}"
+
+  authfile="$(mktemp)"
+  cleanup_paths=("${authfile}")
+  cleanup() {
+    rm -rf "${cleanup_paths[@]}"
+  }
+  trap cleanup EXIT
+  "${SELECT_OCI_AUTH}" "${IMAGE_URL}" >"${authfile}"
+
+  # shellcheck disable=SC2086 # empty-array expansion under set -u
+  retry oras manifest fetch ${oras_opts[@]+"${oras_opts[@]}"} --registry-config "${authfile}" "${IMAGE_REF}" >"${MANIFEST_FILE}"
+
+  # Multi-arch index (e.g. modelcar build-image-index) → one platform manifest.
+  media_type="$(jq -r '.mediaType // ""' "${MANIFEST_FILE}")"
+  if is_image_index "${media_type}"; then
+    child_digest="$(resolve_index_child_digest "${MANIFEST_FILE}")"
+    if [[ -z "${child_digest}" || "${child_digest}" == "null" ]]; then
+      echo "ERROR: image index has no manifests to resolve"
+      exit 1
+    fi
+    echo "INFO: Resolving image index to ${child_digest}"
+    # shellcheck disable=SC2086 # empty-array expansion under set -u
+    retry oras manifest fetch ${oras_opts[@]+"${oras_opts[@]}"} --registry-config "${authfile}" "${IMAGE_URL}@${child_digest}" >"${MANIFEST_FILE}"
+  fi
+
+  config_media_type="$(jq -r '.config.mediaType // ""' "${MANIFEST_FILE}")"
+  is_container_image=false
+  if is_container_image_config "${config_media_type}"; then
+    is_container_image=true
+    echo "INFO: Reference is a container image (${config_media_type}); extracting titled layers matching EXTRA_ARTIFACT_FILTER"
+  fi
+
+  mkdir -p "${SOURCE_ROOT}"
+  fetched_count=0
+
+  if [[ "${is_container_image}" == "true" ]]; then
+    # ModelCar/olot (and similar) store one file per titled tar layer. Fetch only
+    # matching layers — skip base-image layers (no title) and huge weight blobs.
+    while IFS=$'\t' read -r digest media_type title inlayer_path; do
+      [[ -n "${title}" ]] || continue
+      match_path="${inlayer_path:-${title}}"
+      match_path="${match_path#/}"
+      if ! matches_filter "${match_path}" "${title}" "${EXTRA_ARTIFACT_FILTER}"; then
+        continue
+      fi
+
+      tmp_blob="$(mktemp)"
+      tmp_dir="$(mktemp -d)"
+      cleanup_paths+=("${tmp_blob}" "${tmp_dir}")
+      echo "INFO: Fetching layer ${digest} (${title}) for extraction"
+      # shellcheck disable=SC2086 # empty-array expansion under set -u
+      retry oras blob fetch ${oras_opts[@]+"${oras_opts[@]}"} --registry-config "${authfile}" "${IMAGE_URL}@${digest}" --output "${tmp_blob}"
+
+      # olot model files are uncompressed tar; modelcard layers are tar+gzip.
+      extract_tarball "${tmp_blob}" "${tmp_dir}" "${media_type}"
+
+      while IFS= read -r -d '' extracted; do
+        rel_path="${extracted#"${tmp_dir}"/}"
+        rel_path="${rel_path#./}"
+        [[ -n "${rel_path}" ]] || continue
+        if ! dest_path="$(path_allowed "${rel_path}")"; then
+          continue
+        fi
+        mkdir -p "$(dirname "${dest_path}")"
+        cp -a "${extracted}" "${dest_path}"
+        echo "INFO: Extracted ${rel_path}"
+        fetched_count=$((fetched_count + 1))
+      done < <(find "${tmp_dir}" -type f -print0)
+
+      rm -rf "${tmp_blob}" "${tmp_dir}"
+    done < <(jq -r '
+      (.layers // [])[]
+      | [
+          .digest,
+          (.mediaType // ""),
+          (.annotations["org.opencontainers.image.title"] // ""),
+          (.annotations["olot.layer.content.inlayerpath"] // "")
+        ]
+      | @tsv
+    ' "${MANIFEST_FILE}")
+  else
+    while IFS=$'\t' read -r digest rel_path; do
+      [[ -n "${rel_path}" ]] || continue
+      if ! printf '%s\n' "${rel_path}" | grep -Eq "${EXTRA_ARTIFACT_FILTER}"; then
+        continue
+      fi
+
+      if ! dest_path="$(path_allowed "${rel_path}")"; then
+        continue
+      fi
+
+      mkdir -p "$(dirname "${dest_path}")"
+      echo "INFO: Fetching blob ${digest} -> ${rel_path}"
+      # shellcheck disable=SC2086 # empty-array expansion under set -u
+      retry oras blob fetch ${oras_opts[@]+"${oras_opts[@]}"} --registry-config "${authfile}" "${IMAGE_URL}@${digest}" --output "${dest_path}"
+      fetched_count=$((fetched_count + 1))
+    done < <(jq -r '(.layers // [])[] | [.digest, (.annotations["org.opencontainers.image.title"] // "")] | @tsv' "${MANIFEST_FILE}")
+  fi
+
+  if [[ "${fetched_count}" -eq 0 ]]; then
+    echo "INFO: No files matched EXTRA_ARTIFACT_FILTER"
+  else
+    echo "INFO: Fetched ${fetched_count} extra artifact file(s) alongside SOURCE_ARTIFACT"
+  fi
+fi

--- a/task/sast-snyk-check-oci-ta/0.5/recipe.yaml
+++ b/task/sast-snyk-check-oci-ta/0.5/recipe.yaml
@@ -13,11 +13,11 @@ useTAVolumeMount: true
 addParams:
   - name: FETCH_EXTRA_ARTIFACTS
     type: string
-    description: When "true", fetch script-like files from image-url@image-digest (OCI artifact manifest) into /var/workdir/source alongside the restored SOURCE_ARTIFACT. Skipped for standard container images.
+    description: When "true", fetch files matching EXTRA_ARTIFACT_FILTER from image-url@image-digest into /var/workdir/source alongside the restored SOURCE_ARTIFACT. Supports OCI artifacts (raw titled blobs) and container images with titled layers (e.g. ModelCar/olot), extracting matching tar layers without unpacking the full image.
     default: "false"
   - name: EXTRA_ARTIFACT_FILTER
     type: string
-    description: Extended regex matching org.opencontainers.image.title paths in the OCI manifest when FETCH_EXTRA_ARTIFACTS=true.
+    description: Extended regex matched against org.opencontainers.image.title (and olot.layer.content.inlayerpath when present) when FETCH_EXTRA_ARTIFACTS=true.
     default: (^|/)(Dockerfile|Containerfile|[^/]+\.(sh|bash|zsh|ksh|py|rb|pl|js|mjs|cjs|ts|ps1))$
 additionalSteps:
   - at: 1
@@ -62,38 +62,120 @@ additionalSteps:
       echo "INFO: Fetching extra artifacts from OCI reference ${IMAGE_REF}"
 
       authfile="$(mktemp)"
-      trap 'rm -f "${authfile}"' EXIT
+      cleanup_paths=("${authfile}")
+      cleanup() {
+        rm -rf "${cleanup_paths[@]}"
+      }
+      trap cleanup EXIT
       /usr/local/bin/select-oci-auth.sh "${IMAGE_URL}" >"${authfile}"
 
       retry oras manifest fetch "${oras_opts[@]}" --registry-config "${authfile}" "${IMAGE_REF}" >"/tmp/manifest.json"
 
+      # Multi-arch index (e.g. modelcar build-image-index) → one platform manifest.
+      media_type="$(jq -r '.mediaType // ""' /tmp/manifest.json)"
+      if [[ "${media_type}" == "application/vnd.oci.image.index.v1+json" ]] || [[ "${media_type}" == "application/vnd.docker.distribution.manifest.list.v2+json" ]]; then
+        child_digest="$(jq -r '
+          (.manifests // []) as $m
+          | ($m | map(select(.platform.architecture == "amd64" and ((.platform.os // "linux") == "linux"))) | .[0].digest)
+            // ($m | map(select((.platform.os // "linux") == "linux")) | .[0].digest)
+            // ($m[0].digest)
+            // empty
+        ' /tmp/manifest.json)"
+        if [[ -z "${child_digest}" || "${child_digest}" == "null" ]]; then
+          echo "ERROR: image index has no manifests to resolve"
+          exit 1
+        fi
+        echo "INFO: Resolving image index to ${child_digest}"
+        retry oras manifest fetch "${oras_opts[@]}" --registry-config "${authfile}" "${IMAGE_URL}@${child_digest}" >"/tmp/manifest.json"
+      fi
+
       config_media_type="$(jq -r '.config.mediaType // ""' /tmp/manifest.json)"
+      is_container_image=false
       if [[ "${config_media_type}" == "application/vnd.oci.image.config.v1+json" ]] || [[ "${config_media_type}" == "application/vnd.docker.container.image.v1+json" ]]; then
-        echo "INFO: Reference points to a container image config (${config_media_type}); skipping extra artifact fetch"
-        exit 0
+        is_container_image=true
+        echo "INFO: Reference is a container image (${config_media_type}); extracting titled layers matching EXTRA_ARTIFACT_FILTER"
       fi
 
       mkdir -p /var/workdir/source
-
       fetched_count=0
-      while IFS=$'\t' read -r digest rel_path; do
-        [[ -n "${rel_path}" ]] || continue
-        if ! printf '%s\n' "${rel_path}" | grep -Eq "${EXTRA_ARTIFACT_FILTER}"; then
-          continue
-        fi
 
-        dest_path="/var/workdir/source/${rel_path}"
-        resolved_dest="$(realpath -m "${dest_path}")"
+      path_allowed() {
+        local rel_path="$1"
+        local resolved_dest
+        resolved_dest="$(realpath -m "/var/workdir/source/${rel_path}")"
         if [[ ! "${resolved_dest}" == /var/workdir/source/* ]]; then
-          echo "WARN: Skipping path outside source root: ${rel_path}"
-          continue
+          echo "WARN: Skipping path outside source root: ${rel_path}" >&2
+          return 1
         fi
+        printf '%s\n' "${resolved_dest}"
+      }
 
-        mkdir -p "$(dirname "${resolved_dest}")"
-        echo "INFO: Fetching blob ${digest} -> ${rel_path}"
-        retry oras blob fetch "${oras_opts[@]}" --registry-config "${authfile}" "${IMAGE_URL}@${digest}" --output "${resolved_dest}"
-        fetched_count=$((fetched_count + 1))
-      done < <(jq -r '.layers[] | [.digest, (.annotations["org.opencontainers.image.title"] // "")] | @tsv' /tmp/manifest.json)
+      if [[ "${is_container_image}" == "true" ]]; then
+        # ModelCar/olot (and similar) store one file per titled tar layer. Fetch only
+        # matching layers — skip base-image layers (no title) and huge weight blobs.
+        while IFS=$'\t' read -r digest media_type title inlayer_path; do
+          [[ -n "${title}" ]] || continue
+          match_path="${inlayer_path:-${title}}"
+          match_path="${match_path#/}"
+          if ! printf '%s\n' "${match_path}" | grep -Eq "${EXTRA_ARTIFACT_FILTER}" \
+            && ! printf '%s\n' "${title}" | grep -Eq "${EXTRA_ARTIFACT_FILTER}"; then
+            continue
+          fi
+
+          tmp_blob="$(mktemp)"
+          tmp_dir="$(mktemp -d)"
+          cleanup_paths+=("${tmp_blob}" "${tmp_dir}")
+          echo "INFO: Fetching layer ${digest} (${title}) for extraction"
+          retry oras blob fetch "${oras_opts[@]}" --registry-config "${authfile}" "${IMAGE_URL}@${digest}" --output "${tmp_blob}"
+
+          # olot model files are uncompressed tar; modelcard layers are tar+gzip.
+          if [[ "${media_type}" == *gzip* ]] || [[ "${media_type}" == *tar+gzip* ]]; then
+            tar -xzf "${tmp_blob}" -C "${tmp_dir}"
+          else
+            tar -xf "${tmp_blob}" -C "${tmp_dir}"
+          fi
+
+          while IFS= read -r -d '' extracted; do
+            rel_path="${extracted#"${tmp_dir}"/}"
+            rel_path="${rel_path#./}"
+            [[ -n "${rel_path}" ]] || continue
+            if ! dest_path="$(path_allowed "${rel_path}")"; then
+              continue
+            fi
+            mkdir -p "$(dirname "${dest_path}")"
+            cp -a "${extracted}" "${dest_path}"
+            echo "INFO: Extracted ${rel_path}"
+            fetched_count=$((fetched_count + 1))
+          done < <(find "${tmp_dir}" -type f -print0)
+
+          rm -rf "${tmp_blob}" "${tmp_dir}"
+        done < <(jq -r '
+          (.layers // [])[]
+          | [
+              .digest,
+              (.mediaType // ""),
+              (.annotations["org.opencontainers.image.title"] // ""),
+              (.annotations["olot.layer.content.inlayerpath"] // "")
+            ]
+          | @tsv
+        ' /tmp/manifest.json)
+      else
+        while IFS=$'\t' read -r digest rel_path; do
+          [[ -n "${rel_path}" ]] || continue
+          if ! printf '%s\n' "${rel_path}" | grep -Eq "${EXTRA_ARTIFACT_FILTER}"; then
+            continue
+          fi
+
+          if ! dest_path="$(path_allowed "${rel_path}")"; then
+            continue
+          fi
+
+          mkdir -p "$(dirname "${dest_path}")"
+          echo "INFO: Fetching blob ${digest} -> ${rel_path}"
+          retry oras blob fetch "${oras_opts[@]}" --registry-config "${authfile}" "${IMAGE_URL}@${digest}" --output "${dest_path}"
+          fetched_count=$((fetched_count + 1))
+        done < <(jq -r '(.layers // [])[] | [.digest, (.annotations["org.opencontainers.image.title"] // "")] | @tsv' /tmp/manifest.json)
+      fi
 
       if [[ "${fetched_count}" -eq 0 ]]; then
         echo "INFO: No files matched EXTRA_ARTIFACT_FILTER"

--- a/task/sast-snyk-check-oci-ta/0.5/recipe.yaml
+++ b/task/sast-snyk-check-oci-ta/0.5/recipe.yaml
@@ -23,6 +23,7 @@ additionalSteps:
   - at: 1
     name: fetch-extra-artifacts
     # Same pullspec as use-trusted-artifact (oras, select-oci-auth, retry, oras_opts.sh).
+    # Script body is fetch-extra-artifacts.sh (synced by hack/generate-ta-tasks.sh).
     image: quay.io/konflux-ci/build-trusted-artifacts:latest@sha256:0fa7f2a5cd87d6d47ac5dbedc81687805c8e6bc24c6aca620242e9134eed9633
     workingDir: /var/workdir
     volumeMounts:
@@ -43,144 +44,191 @@ additionalSteps:
         value: /etc/pki/tls/certs/ca-custom-bundle.crt
     script: |
       #!/usr/bin/env bash
+      # Fetch files matching EXTRA_ARTIFACT_FILTER from image-url@image-digest into SOURCE_ROOT.
+      # Used by sast-snyk-check-oci-ta fetch-extra-artifacts. Source this file to unit-test helpers.
       set -euo pipefail
 
-      if [[ "${FETCH_EXTRA_ARTIFACTS}" != "true" ]]; then
-        exit 0
-      fi
+      SOURCE_ROOT="${SOURCE_ROOT:-/var/workdir/source}"
+      MANIFEST_FILE="${MANIFEST_FILE:-/tmp/manifest.json}"
+      SELECT_OCI_AUTH="${SELECT_OCI_AUTH:-/usr/local/bin/select-oci-auth.sh}"
+      ORAS_OPTS_FILE="${ORAS_OPTS_FILE:-/usr/local/bin/oras_opts.sh}"
 
-      if [[ -z "${IMAGE_URL}" || -z "${IMAGE_DIGEST}" ]]; then
-        echo "INFO: image-url/image-digest missing, cannot fetch extra artifacts"
-        exit 0
-      fi
-
-      declare -a oras_opts=()
-      # shellcheck source=/dev/null
-      source /usr/local/bin/oras_opts.sh
-
-      IMAGE_REF="${IMAGE_URL}@${IMAGE_DIGEST}"
-      echo "INFO: Fetching extra artifacts from OCI reference ${IMAGE_REF}"
-
-      authfile="$(mktemp)"
-      cleanup_paths=("${authfile}")
-      cleanup() {
-        rm -rf "${cleanup_paths[@]}"
+      is_image_index() {
+        local media_type="$1"
+        [[ "${media_type}" == "application/vnd.oci.image.index.v1+json" ]] ||
+          [[ "${media_type}" == "application/vnd.docker.distribution.manifest.list.v2+json" ]]
       }
-      trap cleanup EXIT
-      /usr/local/bin/select-oci-auth.sh "${IMAGE_URL}" >"${authfile}"
 
-      retry oras manifest fetch "${oras_opts[@]}" --registry-config "${authfile}" "${IMAGE_REF}" >"/tmp/manifest.json"
+      is_container_image_config() {
+        local config_media_type="$1"
+        [[ "${config_media_type}" == "application/vnd.oci.image.config.v1+json" ]] ||
+          [[ "${config_media_type}" == "application/vnd.docker.container.image.v1+json" ]]
+      }
 
-      # Multi-arch index (e.g. modelcar build-image-index) → one platform manifest.
-      media_type="$(jq -r '.mediaType // ""' /tmp/manifest.json)"
-      if [[ "${media_type}" == "application/vnd.oci.image.index.v1+json" ]] || [[ "${media_type}" == "application/vnd.docker.distribution.manifest.list.v2+json" ]]; then
-        child_digest="$(jq -r '
+      resolve_index_child_digest() {
+        local manifest_file="$1"
+        jq -r '
           (.manifests // []) as $m
           | ($m | map(select(.platform.architecture == "amd64" and ((.platform.os // "linux") == "linux"))) | .[0].digest)
             // ($m | map(select((.platform.os // "linux") == "linux")) | .[0].digest)
             // ($m[0].digest)
             // empty
-        ' /tmp/manifest.json)"
-        if [[ -z "${child_digest}" || "${child_digest}" == "null" ]]; then
-          echo "ERROR: image index has no manifests to resolve"
-          exit 1
-        fi
-        echo "INFO: Resolving image index to ${child_digest}"
-        retry oras manifest fetch "${oras_opts[@]}" --registry-config "${authfile}" "${IMAGE_URL}@${child_digest}" >"/tmp/manifest.json"
-      fi
+        ' "${manifest_file}"
+      }
 
-      config_media_type="$(jq -r '.config.mediaType // ""' /tmp/manifest.json)"
-      is_container_image=false
-      if [[ "${config_media_type}" == "application/vnd.oci.image.config.v1+json" ]] || [[ "${config_media_type}" == "application/vnd.docker.container.image.v1+json" ]]; then
-        is_container_image=true
-        echo "INFO: Reference is a container image (${config_media_type}); extracting titled layers matching EXTRA_ARTIFACT_FILTER"
-      fi
-
-      mkdir -p /var/workdir/source
-      fetched_count=0
+      matches_filter() {
+        local match_path="$1"
+        local title="$2"
+        local filter="$3"
+        printf '%s\n' "${match_path}" | grep -Eq "${filter}" && return 0
+        printf '%s\n' "${title}" | grep -Eq "${filter}" && return 0
+        return 1
+      }
 
       path_allowed() {
         local rel_path="$1"
         local resolved_dest
-        resolved_dest="$(realpath -m "/var/workdir/source/${rel_path}")"
-        if [[ ! "${resolved_dest}" == /var/workdir/source/* ]]; then
+        resolved_dest="$(realpath -m "${SOURCE_ROOT}/${rel_path}")"
+        if [[ ! "${resolved_dest}" == "${SOURCE_ROOT}"/* ]]; then
           echo "WARN: Skipping path outside source root: ${rel_path}" >&2
           return 1
         fi
         printf '%s\n' "${resolved_dest}"
       }
 
-      if [[ "${is_container_image}" == "true" ]]; then
-        # ModelCar/olot (and similar) store one file per titled tar layer. Fetch only
-        # matching layers — skip base-image layers (no title) and huge weight blobs.
-        while IFS=$'\t' read -r digest media_type title inlayer_path; do
-          [[ -n "${title}" ]] || continue
-          match_path="${inlayer_path:-${title}}"
-          match_path="${match_path#/}"
-          if ! printf '%s\n' "${match_path}" | grep -Eq "${EXTRA_ARTIFACT_FILTER}" \
-            && ! printf '%s\n' "${title}" | grep -Eq "${EXTRA_ARTIFACT_FILTER}"; then
-            continue
+      extract_tarball() {
+        local blob="$1"
+        local dest="$2"
+        local media_type="$3"
+        if [[ "${media_type}" == *gzip* ]] || [[ "${media_type}" == *tar+gzip* ]]; then
+          tar -xzf "${blob}" -C "${dest}"
+        else
+          tar -xf "${blob}" -C "${dest}"
+        fi
+      }
+
+      if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+        if [[ "${FETCH_EXTRA_ARTIFACTS}" != "true" ]]; then
+          exit 0
+        fi
+
+        if [[ -z "${IMAGE_URL}" || -z "${IMAGE_DIGEST}" ]]; then
+          echo "INFO: image-url/image-digest missing, cannot fetch extra artifacts"
+          exit 0
+        fi
+
+        declare -a oras_opts=()
+        if [[ -f "${ORAS_OPTS_FILE}" ]]; then
+          # shellcheck source=/dev/null
+          source "${ORAS_OPTS_FILE}"
+        fi
+
+        IMAGE_REF="${IMAGE_URL}@${IMAGE_DIGEST}"
+        echo "INFO: Fetching extra artifacts from OCI reference ${IMAGE_REF}"
+
+        authfile="$(mktemp)"
+        cleanup_paths=("${authfile}")
+        cleanup() {
+          rm -rf "${cleanup_paths[@]}"
+        }
+        trap cleanup EXIT
+        "${SELECT_OCI_AUTH}" "${IMAGE_URL}" >"${authfile}"
+
+        # shellcheck disable=SC2086 # empty-array expansion under set -u
+        retry oras manifest fetch ${oras_opts[@]+"${oras_opts[@]}"} --registry-config "${authfile}" "${IMAGE_REF}" >"${MANIFEST_FILE}"
+
+        # Multi-arch index (e.g. modelcar build-image-index) → one platform manifest.
+        media_type="$(jq -r '.mediaType // ""' "${MANIFEST_FILE}")"
+        if is_image_index "${media_type}"; then
+          child_digest="$(resolve_index_child_digest "${MANIFEST_FILE}")"
+          if [[ -z "${child_digest}" || "${child_digest}" == "null" ]]; then
+            echo "ERROR: image index has no manifests to resolve"
+            exit 1
           fi
+          echo "INFO: Resolving image index to ${child_digest}"
+          # shellcheck disable=SC2086 # empty-array expansion under set -u
+          retry oras manifest fetch ${oras_opts[@]+"${oras_opts[@]}"} --registry-config "${authfile}" "${IMAGE_URL}@${child_digest}" >"${MANIFEST_FILE}"
+        fi
 
-          tmp_blob="$(mktemp)"
-          tmp_dir="$(mktemp -d)"
-          cleanup_paths+=("${tmp_blob}" "${tmp_dir}")
-          echo "INFO: Fetching layer ${digest} (${title}) for extraction"
-          retry oras blob fetch "${oras_opts[@]}" --registry-config "${authfile}" "${IMAGE_URL}@${digest}" --output "${tmp_blob}"
+        config_media_type="$(jq -r '.config.mediaType // ""' "${MANIFEST_FILE}")"
+        is_container_image=false
+        if is_container_image_config "${config_media_type}"; then
+          is_container_image=true
+          echo "INFO: Reference is a container image (${config_media_type}); extracting titled layers matching EXTRA_ARTIFACT_FILTER"
+        fi
 
-          # olot model files are uncompressed tar; modelcard layers are tar+gzip.
-          if [[ "${media_type}" == *gzip* ]] || [[ "${media_type}" == *tar+gzip* ]]; then
-            tar -xzf "${tmp_blob}" -C "${tmp_dir}"
-          else
-            tar -xf "${tmp_blob}" -C "${tmp_dir}"
-          fi
+        mkdir -p "${SOURCE_ROOT}"
+        fetched_count=0
 
-          while IFS= read -r -d '' extracted; do
-            rel_path="${extracted#"${tmp_dir}"/}"
-            rel_path="${rel_path#./}"
+        if [[ "${is_container_image}" == "true" ]]; then
+          # ModelCar/olot (and similar) store one file per titled tar layer. Fetch only
+          # matching layers — skip base-image layers (no title) and huge weight blobs.
+          while IFS=$'\t' read -r digest media_type title inlayer_path; do
+            [[ -n "${title}" ]] || continue
+            match_path="${inlayer_path:-${title}}"
+            match_path="${match_path#/}"
+            if ! matches_filter "${match_path}" "${title}" "${EXTRA_ARTIFACT_FILTER}"; then
+              continue
+            fi
+
+            tmp_blob="$(mktemp)"
+            tmp_dir="$(mktemp -d)"
+            cleanup_paths+=("${tmp_blob}" "${tmp_dir}")
+            echo "INFO: Fetching layer ${digest} (${title}) for extraction"
+            # shellcheck disable=SC2086 # empty-array expansion under set -u
+            retry oras blob fetch ${oras_opts[@]+"${oras_opts[@]}"} --registry-config "${authfile}" "${IMAGE_URL}@${digest}" --output "${tmp_blob}"
+
+            # olot model files are uncompressed tar; modelcard layers are tar+gzip.
+            extract_tarball "${tmp_blob}" "${tmp_dir}" "${media_type}"
+
+            while IFS= read -r -d '' extracted; do
+              rel_path="${extracted#"${tmp_dir}"/}"
+              rel_path="${rel_path#./}"
+              [[ -n "${rel_path}" ]] || continue
+              if ! dest_path="$(path_allowed "${rel_path}")"; then
+                continue
+              fi
+              mkdir -p "$(dirname "${dest_path}")"
+              cp -a "${extracted}" "${dest_path}"
+              echo "INFO: Extracted ${rel_path}"
+              fetched_count=$((fetched_count + 1))
+            done < <(find "${tmp_dir}" -type f -print0)
+
+            rm -rf "${tmp_blob}" "${tmp_dir}"
+          done < <(jq -r '
+            (.layers // [])[]
+            | [
+                .digest,
+                (.mediaType // ""),
+                (.annotations["org.opencontainers.image.title"] // ""),
+                (.annotations["olot.layer.content.inlayerpath"] // "")
+              ]
+            | @tsv
+          ' "${MANIFEST_FILE}")
+        else
+          while IFS=$'\t' read -r digest rel_path; do
             [[ -n "${rel_path}" ]] || continue
+            if ! printf '%s\n' "${rel_path}" | grep -Eq "${EXTRA_ARTIFACT_FILTER}"; then
+              continue
+            fi
+
             if ! dest_path="$(path_allowed "${rel_path}")"; then
               continue
             fi
+
             mkdir -p "$(dirname "${dest_path}")"
-            cp -a "${extracted}" "${dest_path}"
-            echo "INFO: Extracted ${rel_path}"
+            echo "INFO: Fetching blob ${digest} -> ${rel_path}"
+            # shellcheck disable=SC2086 # empty-array expansion under set -u
+            retry oras blob fetch ${oras_opts[@]+"${oras_opts[@]}"} --registry-config "${authfile}" "${IMAGE_URL}@${digest}" --output "${dest_path}"
             fetched_count=$((fetched_count + 1))
-          done < <(find "${tmp_dir}" -type f -print0)
+          done < <(jq -r '(.layers // [])[] | [.digest, (.annotations["org.opencontainers.image.title"] // "")] | @tsv' "${MANIFEST_FILE}")
+        fi
 
-          rm -rf "${tmp_blob}" "${tmp_dir}"
-        done < <(jq -r '
-          (.layers // [])[]
-          | [
-              .digest,
-              (.mediaType // ""),
-              (.annotations["org.opencontainers.image.title"] // ""),
-              (.annotations["olot.layer.content.inlayerpath"] // "")
-            ]
-          | @tsv
-        ' /tmp/manifest.json)
-      else
-        while IFS=$'\t' read -r digest rel_path; do
-          [[ -n "${rel_path}" ]] || continue
-          if ! printf '%s\n' "${rel_path}" | grep -Eq "${EXTRA_ARTIFACT_FILTER}"; then
-            continue
-          fi
-
-          if ! dest_path="$(path_allowed "${rel_path}")"; then
-            continue
-          fi
-
-          mkdir -p "$(dirname "${dest_path}")"
-          echo "INFO: Fetching blob ${digest} -> ${rel_path}"
-          retry oras blob fetch "${oras_opts[@]}" --registry-config "${authfile}" "${IMAGE_URL}@${digest}" --output "${dest_path}"
-          fetched_count=$((fetched_count + 1))
-        done < <(jq -r '(.layers // [])[] | [.digest, (.annotations["org.opencontainers.image.title"] // "")] | @tsv' /tmp/manifest.json)
-      fi
-
-      if [[ "${fetched_count}" -eq 0 ]]; then
-        echo "INFO: No files matched EXTRA_ARTIFACT_FILTER"
-      else
-        echo "INFO: Fetched ${fetched_count} extra artifact file(s) alongside SOURCE_ARTIFACT"
+        if [[ "${fetched_count}" -eq 0 ]]; then
+          echo "INFO: No files matched EXTRA_ARTIFACT_FILTER"
+        else
+          echo "INFO: Fetched ${fetched_count} extra artifact file(s) alongside SOURCE_ARTIFACT"
+        fi
       fi
     computeResources:
       limits:

--- a/task/sast-snyk-check-oci-ta/0.5/sast-snyk-check-oci-ta.yaml
+++ b/task/sast-snyk-check-oci-ta/0.5/sast-snyk-check-oci-ta.yaml
@@ -23,14 +23,16 @@ spec:
       type: string
       default: ""
     - name: EXTRA_ARTIFACT_FILTER
-      description: Extended regex matching org.opencontainers.image.title
-        paths in the OCI manifest when FETCH_EXTRA_ARTIFACTS=true.
+      description: Extended regex matched against org.opencontainers.image.title
+        (and olot.layer.content.inlayerpath when present) when FETCH_EXTRA_ARTIFACTS=true.
       type: string
       default: (^|/)(Dockerfile|Containerfile|[^/]+\.(sh|bash|zsh|ksh|py|rb|pl|js|mjs|cjs|ts|ps1))$
     - name: FETCH_EXTRA_ARTIFACTS
-      description: When "true", fetch script-like files from image-url@image-digest
-        (OCI artifact manifest) into /var/workdir/source alongside the restored
-        SOURCE_ARTIFACT. Skipped for standard container images.
+      description: When "true", fetch files matching EXTRA_ARTIFACT_FILTER
+        from image-url@image-digest into /var/workdir/source alongside the
+        restored SOURCE_ARTIFACT. Supports OCI artifacts (raw titled blobs)
+        and container images with titled layers (e.g. ModelCar/olot), extracting
+        matching tar layers without unpacking the full image.
       type: string
       default: "false"
     - name: IGNORE_FILE_PATHS
@@ -113,7 +115,7 @@ spec:
         name: workdir
   steps:
     - name: use-trusted-artifact
-      image: quay.io/konflux-ci/build-trusted-artifacts:latest@sha256:0fa7f2a5cd87d6d47ac5dbedc81687805c8e6bc24c6aca620242e9134eed9633
+      image: quay.io/konflux-ci/build-trusted-artifacts:latest@sha256:dc542700b2e7ba806adfab360682d491c069bc2d6157d235c26adbe09480e26b
       args:
         - use
         - $(params.SOURCE_ARTIFACT)=/var/workdir/source
@@ -167,38 +169,120 @@ spec:
         echo "INFO: Fetching extra artifacts from OCI reference ${IMAGE_REF}"
 
         authfile="$(mktemp)"
-        trap 'rm -f "${authfile}"' EXIT
+        cleanup_paths=("${authfile}")
+        cleanup() {
+          rm -rf "${cleanup_paths[@]}"
+        }
+        trap cleanup EXIT
         /usr/local/bin/select-oci-auth.sh "${IMAGE_URL}" >"${authfile}"
 
         retry oras manifest fetch "${oras_opts[@]}" --registry-config "${authfile}" "${IMAGE_REF}" >"/tmp/manifest.json"
 
+        # Multi-arch index (e.g. modelcar build-image-index) → one platform manifest.
+        media_type="$(jq -r '.mediaType // ""' /tmp/manifest.json)"
+        if [[ "${media_type}" == "application/vnd.oci.image.index.v1+json" ]] || [[ "${media_type}" == "application/vnd.docker.distribution.manifest.list.v2+json" ]]; then
+          child_digest="$(jq -r '
+            (.manifests // []) as $m
+            | ($m | map(select(.platform.architecture == "amd64" and ((.platform.os // "linux") == "linux"))) | .[0].digest)
+              // ($m | map(select((.platform.os // "linux") == "linux")) | .[0].digest)
+              // ($m[0].digest)
+              // empty
+          ' /tmp/manifest.json)"
+          if [[ -z "${child_digest}" || "${child_digest}" == "null" ]]; then
+            echo "ERROR: image index has no manifests to resolve"
+            exit 1
+          fi
+          echo "INFO: Resolving image index to ${child_digest}"
+          retry oras manifest fetch "${oras_opts[@]}" --registry-config "${authfile}" "${IMAGE_URL}@${child_digest}" >"/tmp/manifest.json"
+        fi
+
         config_media_type="$(jq -r '.config.mediaType // ""' /tmp/manifest.json)"
+        is_container_image=false
         if [[ "${config_media_type}" == "application/vnd.oci.image.config.v1+json" ]] || [[ "${config_media_type}" == "application/vnd.docker.container.image.v1+json" ]]; then
-          echo "INFO: Reference points to a container image config (${config_media_type}); skipping extra artifact fetch"
-          exit 0
+          is_container_image=true
+          echo "INFO: Reference is a container image (${config_media_type}); extracting titled layers matching EXTRA_ARTIFACT_FILTER"
         fi
 
         mkdir -p /var/workdir/source
-
         fetched_count=0
-        while IFS=$'\t' read -r digest rel_path; do
-          [[ -n "${rel_path}" ]] || continue
-          if ! printf '%s\n' "${rel_path}" | grep -Eq "${EXTRA_ARTIFACT_FILTER}"; then
-            continue
-          fi
 
-          dest_path="/var/workdir/source/${rel_path}"
-          resolved_dest="$(realpath -m "${dest_path}")"
+        path_allowed() {
+          local rel_path="$1"
+          local resolved_dest
+          resolved_dest="$(realpath -m "/var/workdir/source/${rel_path}")"
           if [[ ! "${resolved_dest}" == /var/workdir/source/* ]]; then
-            echo "WARN: Skipping path outside source root: ${rel_path}"
-            continue
+            echo "WARN: Skipping path outside source root: ${rel_path}" >&2
+            return 1
           fi
+          printf '%s\n' "${resolved_dest}"
+        }
 
-          mkdir -p "$(dirname "${resolved_dest}")"
-          echo "INFO: Fetching blob ${digest} -> ${rel_path}"
-          retry oras blob fetch "${oras_opts[@]}" --registry-config "${authfile}" "${IMAGE_URL}@${digest}" --output "${resolved_dest}"
-          fetched_count=$((fetched_count + 1))
-        done < <(jq -r '.layers[] | [.digest, (.annotations["org.opencontainers.image.title"] // "")] | @tsv' /tmp/manifest.json)
+        if [[ "${is_container_image}" == "true" ]]; then
+          # ModelCar/olot (and similar) store one file per titled tar layer. Fetch only
+          # matching layers — skip base-image layers (no title) and huge weight blobs.
+          while IFS=$'\t' read -r digest media_type title inlayer_path; do
+            [[ -n "${title}" ]] || continue
+            match_path="${inlayer_path:-${title}}"
+            match_path="${match_path#/}"
+            if ! printf '%s\n' "${match_path}" | grep -Eq "${EXTRA_ARTIFACT_FILTER}" &&
+                 ! printf '%s\n' "${title}" | grep -Eq "${EXTRA_ARTIFACT_FILTER}"; then
+              continue
+            fi
+
+            tmp_blob="$(mktemp)"
+            tmp_dir="$(mktemp -d)"
+            cleanup_paths+=("${tmp_blob}" "${tmp_dir}")
+            echo "INFO: Fetching layer ${digest} (${title}) for extraction"
+            retry oras blob fetch "${oras_opts[@]}" --registry-config "${authfile}" "${IMAGE_URL}@${digest}" --output "${tmp_blob}"
+
+            # olot model files are uncompressed tar; modelcard layers are tar+gzip.
+            if [[ "${media_type}" == *gzip* ]] || [[ "${media_type}" == *tar+gzip* ]]; then
+              tar -xzf "${tmp_blob}" -C "${tmp_dir}"
+            else
+              tar -xf "${tmp_blob}" -C "${tmp_dir}"
+            fi
+
+            while IFS= read -r -d '' extracted; do
+              rel_path="${extracted#"${tmp_dir}"/}"
+              rel_path="${rel_path#./}"
+              [[ -n "${rel_path}" ]] || continue
+              if ! dest_path="$(path_allowed "${rel_path}")"; then
+                continue
+              fi
+              mkdir -p "$(dirname "${dest_path}")"
+              cp -a "${extracted}" "${dest_path}"
+              echo "INFO: Extracted ${rel_path}"
+              fetched_count=$((fetched_count + 1))
+            done < <(find "${tmp_dir}" -type f -print0)
+
+            rm -rf "${tmp_blob}" "${tmp_dir}"
+          done < <(jq -r '
+            (.layers // [])[]
+            | [
+                .digest,
+                (.mediaType // ""),
+                (.annotations["org.opencontainers.image.title"] // ""),
+                (.annotations["olot.layer.content.inlayerpath"] // "")
+              ]
+            | @tsv
+          ' /tmp/manifest.json)
+        else
+          while IFS=$'\t' read -r digest rel_path; do
+            [[ -n "${rel_path}" ]] || continue
+            if ! printf '%s\n' "${rel_path}" | grep -Eq "${EXTRA_ARTIFACT_FILTER}"; then
+              continue
+            fi
+
+            if ! dest_path="$(path_allowed "${rel_path}")"; then
+              continue
+            fi
+
+            mkdir -p "$(dirname "${dest_path}")"
+            echo "INFO: Fetching blob ${digest} -> ${rel_path}"
+            retry oras blob fetch "${oras_opts[@]}" --registry-config "${authfile}" "${IMAGE_URL}@${digest}" --output "${dest_path}"
+            fetched_count=$((fetched_count + 1))
+          done < <(jq -r '(.layers // [])[] | [.digest, (.annotations["org.opencontainers.image.title"] // "")] | @tsv' /tmp/manifest.json)
+        fi
 
         if [[ "${fetched_count}" -eq 0 ]]; then
           echo "INFO: No files matched EXTRA_ARTIFACT_FILTER"

--- a/task/sast-snyk-check-oci-ta/0.5/sast-snyk-check-oci-ta.yaml
+++ b/task/sast-snyk-check-oci-ta/0.5/sast-snyk-check-oci-ta.yaml
@@ -150,144 +150,191 @@ spec:
           value: /etc/pki/tls/certs/ca-custom-bundle.crt
       script: |
         #!/usr/bin/env bash
+        # Fetch files matching EXTRA_ARTIFACT_FILTER from image-url@image-digest into SOURCE_ROOT.
+        # Used by sast-snyk-check-oci-ta fetch-extra-artifacts. Source this file to unit-test helpers.
         set -euo pipefail
 
-        if [[ "${FETCH_EXTRA_ARTIFACTS}" != "true" ]]; then
-          exit 0
-        fi
+        SOURCE_ROOT="${SOURCE_ROOT:-/var/workdir/source}"
+        MANIFEST_FILE="${MANIFEST_FILE:-/tmp/manifest.json}"
+        SELECT_OCI_AUTH="${SELECT_OCI_AUTH:-/usr/local/bin/select-oci-auth.sh}"
+        ORAS_OPTS_FILE="${ORAS_OPTS_FILE:-/usr/local/bin/oras_opts.sh}"
 
-        if [[ -z "${IMAGE_URL}" || -z "${IMAGE_DIGEST}" ]]; then
-          echo "INFO: image-url/image-digest missing, cannot fetch extra artifacts"
-          exit 0
-        fi
-
-        declare -a oras_opts=()
-        # shellcheck source=/dev/null
-        source /usr/local/bin/oras_opts.sh
-
-        IMAGE_REF="${IMAGE_URL}@${IMAGE_DIGEST}"
-        echo "INFO: Fetching extra artifacts from OCI reference ${IMAGE_REF}"
-
-        authfile="$(mktemp)"
-        cleanup_paths=("${authfile}")
-        cleanup() {
-          rm -rf "${cleanup_paths[@]}"
+        is_image_index() {
+          local media_type="$1"
+          [[ "${media_type}" == "application/vnd.oci.image.index.v1+json" ]] ||
+            [[ "${media_type}" == "application/vnd.docker.distribution.manifest.list.v2+json" ]]
         }
-        trap cleanup EXIT
-        /usr/local/bin/select-oci-auth.sh "${IMAGE_URL}" >"${authfile}"
 
-        retry oras manifest fetch "${oras_opts[@]}" --registry-config "${authfile}" "${IMAGE_REF}" >"/tmp/manifest.json"
+        is_container_image_config() {
+          local config_media_type="$1"
+          [[ "${config_media_type}" == "application/vnd.oci.image.config.v1+json" ]] ||
+            [[ "${config_media_type}" == "application/vnd.docker.container.image.v1+json" ]]
+        }
 
-        # Multi-arch index (e.g. modelcar build-image-index) → one platform manifest.
-        media_type="$(jq -r '.mediaType // ""' /tmp/manifest.json)"
-        if [[ "${media_type}" == "application/vnd.oci.image.index.v1+json" ]] || [[ "${media_type}" == "application/vnd.docker.distribution.manifest.list.v2+json" ]]; then
-          child_digest="$(jq -r '
+        resolve_index_child_digest() {
+          local manifest_file="$1"
+          jq -r '
             (.manifests // []) as $m
             | ($m | map(select(.platform.architecture == "amd64" and ((.platform.os // "linux") == "linux"))) | .[0].digest)
               // ($m | map(select((.platform.os // "linux") == "linux")) | .[0].digest)
               // ($m[0].digest)
               // empty
-          ' /tmp/manifest.json)"
-          if [[ -z "${child_digest}" || "${child_digest}" == "null" ]]; then
-            echo "ERROR: image index has no manifests to resolve"
-            exit 1
-          fi
-          echo "INFO: Resolving image index to ${child_digest}"
-          retry oras manifest fetch "${oras_opts[@]}" --registry-config "${authfile}" "${IMAGE_URL}@${child_digest}" >"/tmp/manifest.json"
-        fi
+          ' "${manifest_file}"
+        }
 
-        config_media_type="$(jq -r '.config.mediaType // ""' /tmp/manifest.json)"
-        is_container_image=false
-        if [[ "${config_media_type}" == "application/vnd.oci.image.config.v1+json" ]] || [[ "${config_media_type}" == "application/vnd.docker.container.image.v1+json" ]]; then
-          is_container_image=true
-          echo "INFO: Reference is a container image (${config_media_type}); extracting titled layers matching EXTRA_ARTIFACT_FILTER"
-        fi
-
-        mkdir -p /var/workdir/source
-        fetched_count=0
+        matches_filter() {
+          local match_path="$1"
+          local title="$2"
+          local filter="$3"
+          printf '%s\n' "${match_path}" | grep -Eq "${filter}" && return 0
+          printf '%s\n' "${title}" | grep -Eq "${filter}" && return 0
+          return 1
+        }
 
         path_allowed() {
           local rel_path="$1"
           local resolved_dest
-          resolved_dest="$(realpath -m "/var/workdir/source/${rel_path}")"
-          if [[ ! "${resolved_dest}" == /var/workdir/source/* ]]; then
+          resolved_dest="$(realpath -m "${SOURCE_ROOT}/${rel_path}")"
+          if [[ ! "${resolved_dest}" == "${SOURCE_ROOT}"/* ]]; then
             echo "WARN: Skipping path outside source root: ${rel_path}" >&2
             return 1
           fi
           printf '%s\n' "${resolved_dest}"
         }
 
-        if [[ "${is_container_image}" == "true" ]]; then
-          # ModelCar/olot (and similar) store one file per titled tar layer. Fetch only
-          # matching layers — skip base-image layers (no title) and huge weight blobs.
-          while IFS=$'\t' read -r digest media_type title inlayer_path; do
-            [[ -n "${title}" ]] || continue
-            match_path="${inlayer_path:-${title}}"
-            match_path="${match_path#/}"
-            if ! printf '%s\n' "${match_path}" | grep -Eq "${EXTRA_ARTIFACT_FILTER}" &&
-                 ! printf '%s\n' "${title}" | grep -Eq "${EXTRA_ARTIFACT_FILTER}"; then
-              continue
+        extract_tarball() {
+          local blob="$1"
+          local dest="$2"
+          local media_type="$3"
+          if [[ "${media_type}" == *gzip* ]] || [[ "${media_type}" == *tar+gzip* ]]; then
+            tar -xzf "${blob}" -C "${dest}"
+          else
+            tar -xf "${blob}" -C "${dest}"
+          fi
+        }
+
+        if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+          if [[ "${FETCH_EXTRA_ARTIFACTS}" != "true" ]]; then
+            exit 0
+          fi
+
+          if [[ -z "${IMAGE_URL}" || -z "${IMAGE_DIGEST}" ]]; then
+            echo "INFO: image-url/image-digest missing, cannot fetch extra artifacts"
+            exit 0
+          fi
+
+          declare -a oras_opts=()
+          if [[ -f "${ORAS_OPTS_FILE}" ]]; then
+            # shellcheck source=/dev/null
+            source "${ORAS_OPTS_FILE}"
+          fi
+
+          IMAGE_REF="${IMAGE_URL}@${IMAGE_DIGEST}"
+          echo "INFO: Fetching extra artifacts from OCI reference ${IMAGE_REF}"
+
+          authfile="$(mktemp)"
+          cleanup_paths=("${authfile}")
+          cleanup() {
+            rm -rf "${cleanup_paths[@]}"
+          }
+          trap cleanup EXIT
+          "${SELECT_OCI_AUTH}" "${IMAGE_URL}" >"${authfile}"
+
+          # shellcheck disable=SC2086 # empty-array expansion under set -u
+          retry oras manifest fetch ${oras_opts[@]+"${oras_opts[@]}"} --registry-config "${authfile}" "${IMAGE_REF}" >"${MANIFEST_FILE}"
+
+          # Multi-arch index (e.g. modelcar build-image-index) → one platform manifest.
+          media_type="$(jq -r '.mediaType // ""' "${MANIFEST_FILE}")"
+          if is_image_index "${media_type}"; then
+            child_digest="$(resolve_index_child_digest "${MANIFEST_FILE}")"
+            if [[ -z "${child_digest}" || "${child_digest}" == "null" ]]; then
+              echo "ERROR: image index has no manifests to resolve"
+              exit 1
             fi
+            echo "INFO: Resolving image index to ${child_digest}"
+            # shellcheck disable=SC2086 # empty-array expansion under set -u
+            retry oras manifest fetch ${oras_opts[@]+"${oras_opts[@]}"} --registry-config "${authfile}" "${IMAGE_URL}@${child_digest}" >"${MANIFEST_FILE}"
+          fi
 
-            tmp_blob="$(mktemp)"
-            tmp_dir="$(mktemp -d)"
-            cleanup_paths+=("${tmp_blob}" "${tmp_dir}")
-            echo "INFO: Fetching layer ${digest} (${title}) for extraction"
-            retry oras blob fetch "${oras_opts[@]}" --registry-config "${authfile}" "${IMAGE_URL}@${digest}" --output "${tmp_blob}"
+          config_media_type="$(jq -r '.config.mediaType // ""' "${MANIFEST_FILE}")"
+          is_container_image=false
+          if is_container_image_config "${config_media_type}"; then
+            is_container_image=true
+            echo "INFO: Reference is a container image (${config_media_type}); extracting titled layers matching EXTRA_ARTIFACT_FILTER"
+          fi
 
-            # olot model files are uncompressed tar; modelcard layers are tar+gzip.
-            if [[ "${media_type}" == *gzip* ]] || [[ "${media_type}" == *tar+gzip* ]]; then
-              tar -xzf "${tmp_blob}" -C "${tmp_dir}"
-            else
-              tar -xf "${tmp_blob}" -C "${tmp_dir}"
-            fi
+          mkdir -p "${SOURCE_ROOT}"
+          fetched_count=0
 
-            while IFS= read -r -d '' extracted; do
-              rel_path="${extracted#"${tmp_dir}"/}"
-              rel_path="${rel_path#./}"
+          if [[ "${is_container_image}" == "true" ]]; then
+            # ModelCar/olot (and similar) store one file per titled tar layer. Fetch only
+            # matching layers — skip base-image layers (no title) and huge weight blobs.
+            while IFS=$'\t' read -r digest media_type title inlayer_path; do
+              [[ -n "${title}" ]] || continue
+              match_path="${inlayer_path:-${title}}"
+              match_path="${match_path#/}"
+              if ! matches_filter "${match_path}" "${title}" "${EXTRA_ARTIFACT_FILTER}"; then
+                continue
+              fi
+
+              tmp_blob="$(mktemp)"
+              tmp_dir="$(mktemp -d)"
+              cleanup_paths+=("${tmp_blob}" "${tmp_dir}")
+              echo "INFO: Fetching layer ${digest} (${title}) for extraction"
+              # shellcheck disable=SC2086 # empty-array expansion under set -u
+              retry oras blob fetch ${oras_opts[@]+"${oras_opts[@]}"} --registry-config "${authfile}" "${IMAGE_URL}@${digest}" --output "${tmp_blob}"
+
+              # olot model files are uncompressed tar; modelcard layers are tar+gzip.
+              extract_tarball "${tmp_blob}" "${tmp_dir}" "${media_type}"
+
+              while IFS= read -r -d '' extracted; do
+                rel_path="${extracted#"${tmp_dir}"/}"
+                rel_path="${rel_path#./}"
+                [[ -n "${rel_path}" ]] || continue
+                if ! dest_path="$(path_allowed "${rel_path}")"; then
+                  continue
+                fi
+                mkdir -p "$(dirname "${dest_path}")"
+                cp -a "${extracted}" "${dest_path}"
+                echo "INFO: Extracted ${rel_path}"
+                fetched_count=$((fetched_count + 1))
+              done < <(find "${tmp_dir}" -type f -print0)
+
+              rm -rf "${tmp_blob}" "${tmp_dir}"
+            done < <(jq -r '
+              (.layers // [])[]
+              | [
+                  .digest,
+                  (.mediaType // ""),
+                  (.annotations["org.opencontainers.image.title"] // ""),
+                  (.annotations["olot.layer.content.inlayerpath"] // "")
+                ]
+              | @tsv
+            ' "${MANIFEST_FILE}")
+          else
+            while IFS=$'\t' read -r digest rel_path; do
               [[ -n "${rel_path}" ]] || continue
+              if ! printf '%s\n' "${rel_path}" | grep -Eq "${EXTRA_ARTIFACT_FILTER}"; then
+                continue
+              fi
+
               if ! dest_path="$(path_allowed "${rel_path}")"; then
                 continue
               fi
+
               mkdir -p "$(dirname "${dest_path}")"
-              cp -a "${extracted}" "${dest_path}"
-              echo "INFO: Extracted ${rel_path}"
+              echo "INFO: Fetching blob ${digest} -> ${rel_path}"
+              # shellcheck disable=SC2086 # empty-array expansion under set -u
+              retry oras blob fetch ${oras_opts[@]+"${oras_opts[@]}"} --registry-config "${authfile}" "${IMAGE_URL}@${digest}" --output "${dest_path}"
               fetched_count=$((fetched_count + 1))
-            done < <(find "${tmp_dir}" -type f -print0)
+            done < <(jq -r '(.layers // [])[] | [.digest, (.annotations["org.opencontainers.image.title"] // "")] | @tsv' "${MANIFEST_FILE}")
+          fi
 
-            rm -rf "${tmp_blob}" "${tmp_dir}"
-          done < <(jq -r '
-            (.layers // [])[]
-            | [
-                .digest,
-                (.mediaType // ""),
-                (.annotations["org.opencontainers.image.title"] // ""),
-                (.annotations["olot.layer.content.inlayerpath"] // "")
-              ]
-            | @tsv
-          ' /tmp/manifest.json)
-        else
-          while IFS=$'\t' read -r digest rel_path; do
-            [[ -n "${rel_path}" ]] || continue
-            if ! printf '%s\n' "${rel_path}" | grep -Eq "${EXTRA_ARTIFACT_FILTER}"; then
-              continue
-            fi
-
-            if ! dest_path="$(path_allowed "${rel_path}")"; then
-              continue
-            fi
-
-            mkdir -p "$(dirname "${dest_path}")"
-            echo "INFO: Fetching blob ${digest} -> ${rel_path}"
-            retry oras blob fetch "${oras_opts[@]}" --registry-config "${authfile}" "${IMAGE_URL}@${digest}" --output "${dest_path}"
-            fetched_count=$((fetched_count + 1))
-          done < <(jq -r '(.layers // [])[] | [.digest, (.annotations["org.opencontainers.image.title"] // "")] | @tsv' /tmp/manifest.json)
-        fi
-
-        if [[ "${fetched_count}" -eq 0 ]]; then
-          echo "INFO: No files matched EXTRA_ARTIFACT_FILTER"
-        else
-          echo "INFO: Fetched ${fetched_count} extra artifact file(s) alongside SOURCE_ARTIFACT"
+          if [[ "${fetched_count}" -eq 0 ]]; then
+            echo "INFO: No files matched EXTRA_ARTIFACT_FILTER"
+          else
+            echo "INFO: Fetched ${fetched_count} extra artifact file(s) alongside SOURCE_ARTIFACT"
+          fi
         fi
       computeResources:
         limits:

--- a/task/sast-snyk-check-oci-ta/0.5/tests/check-container-layer-extract.sh
+++ b/task/sast-snyk-check-oci-ta/0.5/tests/check-container-layer-extract.sh
@@ -1,62 +1,188 @@
 #!/usr/bin/env bash
-# ponytail: local self-check for titled container-layer extract + filter logic.
-# Fails if matching model metadata is not extracted, or if weight-like titles would match.
+# Unit tests for fetch-extra-artifacts.sh (titled container-layer extract + filter).
+# Run locally or via tests/test-sast-snyk-check-oci-ta-container-layers.yaml in CI.
 set -euo pipefail
 
-EXTRA_ARTIFACT_FILTER='(^|/)(Dockerfile|Containerfile|[^/]+\.(json|jinja|py|rb|pl|js|mjs|cjs|ts|ps1|sh|bash|zsh|ksh|md|yaml|yml|txt|model))$'
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+if [[ -f "${HERE}/fetch-extra-artifacts.sh" ]]; then
+  FETCH_SCRIPT="${HERE}/fetch-extra-artifacts.sh"
+else
+  FETCH_SCRIPT="${HERE}/../fetch-extra-artifacts.sh"
+fi
 
+# shellcheck disable=SC1091
+source "${FETCH_SCRIPT}"
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+assert_eq() {
+  local got="$1" want="$2" msg="$3"
+  [[ "${got}" == "${want}" ]] || fail "${msg}: got '${got}' want '${want}'"
+}
+
+MODEL_FILTER='(^|/)(Dockerfile|Containerfile|[^/]+\.(json|jinja|py|rb|pl|js|mjs|cjs|ts|ps1|sh|bash|zsh|ksh|md|yaml|yml|txt|model))$'
+
+command -v jq >/dev/null || fail "jq is required"
+
+# --- filter ---
+matches_filter "models/config.json" "config.json" "${MODEL_FILTER}" ||
+  fail "expected models/config.json to match EXTRA_ARTIFACT_FILTER"
+matches_filter "config.json" "config.json" "${MODEL_FILTER}" ||
+  fail "expected title config.json to match EXTRA_ARTIFACT_FILTER"
+if matches_filter "model.safetensors" "model.safetensors" "${MODEL_FILTER}"; then
+  fail "safetensors must not match EXTRA_ARTIFACT_FILTER"
+fi
+is_container_image_config "application/vnd.oci.image.config.v1+json" ||
+  fail "expected oci image config to be detected"
+is_image_index "application/vnd.oci.image.index.v1+json" ||
+  fail "expected oci image index to be detected"
+if is_image_index "application/vnd.oci.image.manifest.v1+json"; then
+  fail "image manifest must not be treated as an index"
+fi
+
+# --- index resolve ---
+index_dir="$(mktemp -d)"
+trap 'rm -rf "${index_dir}"' EXIT
+cat >"${index_dir}/index.json" <<'EOF'
+{
+  "mediaType": "application/vnd.oci.image.index.v1+json",
+  "manifests": [
+    {"digest": "sha256:arm", "platform": {"architecture": "arm64", "os": "linux"}},
+    {"digest": "sha256:amd", "platform": {"architecture": "amd64", "os": "linux"}}
+  ]
+}
+EOF
+assert_eq "$(resolve_index_child_digest "${index_dir}/index.json")" "sha256:amd" "linux/amd64 digest"
+
+cat >"${index_dir}/linux-only.json" <<'EOF'
+{
+  "manifests": [
+    {"digest": "sha256:arm", "platform": {"architecture": "arm64", "os": "linux"}}
+  ]
+}
+EOF
+assert_eq "$(resolve_index_child_digest "${index_dir}/linux-only.json")" "sha256:arm" "first linux digest fallback"
+
+# --- tar extract (olot-style titled layer) ---
 workdir="$(mktemp -d)"
-trap 'rm -rf "${workdir}"' EXIT
-mkdir -p "${workdir}/source" "${workdir}/layer"
-
-# Simulate an olot model layer member at models/config.json
-# (olot uses arcname /models/...; extractors typically strip the leading /)
-mkdir -p "${workdir}/layer/models"
+mkdir -p "${workdir}/layer/models" "${workdir}/source"
 printf '{"ok":true}\n' >"${workdir}/layer/models/config.json"
 tar -cf "${workdir}/layer.tar" -C "${workdir}/layer" models/config.json
+extract_dir="$(mktemp -d)"
+extract_tarball "${workdir}/layer.tar" "${extract_dir}" "application/vnd.oci.image.layer.v1.tar"
+[[ -f "${extract_dir}/models/config.json" ]] || fail "missing extracted models/config.json"
+grep -q '{"ok":true}' "${extract_dir}/models/config.json" || fail "extracted file content mismatch"
 
-title="config.json"
-inlayer_path="/models/config.json"
-match_path="${inlayer_path#/}"
-if ! printf '%s\n' "${match_path}" | grep -Eq "${EXTRA_ARTIFACT_FILTER}" \
-  && ! printf '%s\n' "${title}" | grep -Eq "${EXTRA_ARTIFACT_FILTER}"; then
-  echo "FAIL: expected config.json to match EXTRA_ARTIFACT_FILTER" >&2
-  exit 1
+gz_dir="$(mktemp -d)"
+tar -czf "${workdir}/layer.tar.gz" -C "${workdir}/layer" models/config.json
+extract_tarball "${workdir}/layer.tar.gz" "${gz_dir}" "application/vnd.oci.image.layer.v1.tar+gzip"
+[[ -f "${gz_dir}/models/config.json" ]] || fail "missing gzip-extracted models/config.json"
+
+# --- mocked oras: container image titled layer ---
+if ! realpath -m / >/dev/null 2>&1; then
+  echo "SKIP: GNU realpath -m not available; mocked oras path not run"
+  echo "OK: container titled-layer extract self-check passed"
+  exit 0
 fi
 
-weight_title="model.safetensors"
-if printf '%s\n' "${weight_title}" | grep -Eq "${EXTRA_ARTIFACT_FILTER}"; then
-  echo "FAIL: safetensors must not match EXTRA_ARTIFACT_FILTER" >&2
-  exit 1
-fi
+fake_bin="$(mktemp -d)"
+blob_dir="$(mktemp -d)"
+digest="sha256:layer1"
+cp "${workdir}/layer.tar" "${blob_dir}/${digest}"
 
-tmp_dir="$(mktemp -d)"
-tar -xf "${workdir}/layer.tar" -C "${tmp_dir}"
-fetched_count=0
-while IFS= read -r -d '' extracted; do
-  rel_path="${extracted#"${tmp_dir}"/}"
-  rel_path="${rel_path#./}"
-  # Task image has GNU realpath -m; keep this check portable for macOS hosts.
-  if [[ "${rel_path}" == *".."* ]]; then
-    echo "FAIL: path escape: ${rel_path}" >&2
-    exit 1
-  fi
-  dest_path="${workdir}/source/${rel_path}"
-  mkdir -p "$(dirname "${dest_path}")"
-  cp -a "${extracted}" "${dest_path}"
-  fetched_count=$((fetched_count + 1))
-done < <(find "${tmp_dir}" -type f -print0)
-rm -rf "${tmp_dir}"
+cat >"${fake_bin}/oras" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+if [[ "${1:-}" == "manifest" && "${2:-}" == "fetch" ]]; then
+  cat "${MOCK_MANIFEST}"
+  exit 0
+fi
+if [[ "${1:-}" == "blob" && "${2:-}" == "fetch" ]]; then
+  out=""
+  ref=""
+  while [[ $# -gt 0 ]]; do
+    if [[ "$1" == "--output" ]]; then
+      out="$2"
+      shift 2
+      continue
+    fi
+    if [[ "$1" == *@sha256:* ]]; then
+      ref="$1"
+    fi
+    shift
+  done
+  digest="${ref##*@}"
+  cp "${MOCK_BLOB_DIR}/${digest}" "${out}"
+  exit 0
+fi
+echo "unexpected oras args: $*" >&2
+exit 1
+EOF
+cat >"${fake_bin}/select-oci-auth.sh" <<'EOF'
+#!/usr/bin/env bash
+echo '{}'
+EOF
+cat >"${fake_bin}/retry" <<'EOF'
+#!/usr/bin/env bash
+exec "$@"
+EOF
+chmod +x "${fake_bin}/oras" "${fake_bin}/select-oci-auth.sh" "${fake_bin}/retry"
 
-if [[ "${fetched_count}" -ne 1 ]]; then
-  echo "FAIL: expected 1 extracted file, got ${fetched_count}" >&2
-  exit 1
+MOCK_MANIFEST="${index_dir}/image-manifest.json"
+cat >"${MOCK_MANIFEST}" <<EOF
+{
+  "mediaType": "application/vnd.oci.image.manifest.v1+json",
+  "config": {"mediaType": "application/vnd.oci.image.config.v1+json"},
+  "layers": [
+    {
+      "digest": "${digest}",
+      "mediaType": "application/vnd.oci.image.layer.v1.tar",
+      "annotations": {
+        "org.opencontainers.image.title": "config.json",
+        "olot.layer.content.inlayerpath": "/models/config.json"
+      }
+    },
+    {
+      "digest": "sha256:weights",
+      "mediaType": "application/vnd.oci.image.layer.v1.tar",
+      "annotations": {
+        "org.opencontainers.image.title": "model.safetensors"
+      }
+    },
+    {
+      "digest": "sha256:base",
+      "mediaType": "application/vnd.oci.image.layer.v1.tar"
+    }
+  ]
+}
+EOF
+
+source_root="$(mktemp -d)/source"
+mkdir -p "${source_root}"
+PATH="${fake_bin}:${PATH}" \
+  MOCK_MANIFEST="${MOCK_MANIFEST}" \
+  MOCK_BLOB_DIR="${blob_dir}" \
+  ORAS_OPTS_FILE="/no-such-oras-opts" \
+  SELECT_OCI_AUTH="${fake_bin}/select-oci-auth.sh" \
+  SOURCE_ROOT="${source_root}" \
+  MANIFEST_FILE="${index_dir}/runtime-manifest.json" \
+  FETCH_EXTRA_ARTIFACTS="true" \
+  EXTRA_ARTIFACT_FILTER="${MODEL_FILTER}" \
+  IMAGE_URL="fake.example/modelcar" \
+  IMAGE_DIGEST="sha256:index" \
+  bash "${FETCH_SCRIPT}"
+
+[[ -f "${source_root}/models/config.json" ]] || fail "mocked fetch did not extract models/config.json"
+if [[ -e "${source_root}/model.safetensors" ]]; then
+  fail "weight blob must not be fetched"
 fi
-if [[ ! -f "${workdir}/source/models/config.json" ]]; then
-  echo "FAIL: missing ${workdir}/source/models/config.json" >&2
-  find "${workdir}/source" -print >&2 || true
-  exit 1
-fi
-grep -q '{"ok":true}' "${workdir}/source/models/config.json"
+grep -q '{"ok":true}' "${source_root}/models/config.json" || fail "extracted artifact content mismatch"
+
+# default-off
+FETCH_EXTRA_ARTIFACTS="false" IMAGE_URL="x" IMAGE_DIGEST="y" bash "${FETCH_SCRIPT}" ||
+  fail "FETCH_EXTRA_ARTIFACTS=false must exit 0"
 
 echo "OK: container titled-layer extract self-check passed"

--- a/task/sast-snyk-check-oci-ta/0.5/tests/check-container-layer-extract.sh
+++ b/task/sast-snyk-check-oci-ta/0.5/tests/check-container-layer-extract.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# ponytail: local self-check for titled container-layer extract + filter logic.
+# Fails if matching model metadata is not extracted, or if weight-like titles would match.
+set -euo pipefail
+
+EXTRA_ARTIFACT_FILTER='(^|/)(Dockerfile|Containerfile|[^/]+\.(json|jinja|py|rb|pl|js|mjs|cjs|ts|ps1|sh|bash|zsh|ksh|md|yaml|yml|txt|model))$'
+
+workdir="$(mktemp -d)"
+trap 'rm -rf "${workdir}"' EXIT
+mkdir -p "${workdir}/source" "${workdir}/layer"
+
+# Simulate an olot model layer member at models/config.json
+# (olot uses arcname /models/...; extractors typically strip the leading /)
+mkdir -p "${workdir}/layer/models"
+printf '{"ok":true}\n' >"${workdir}/layer/models/config.json"
+tar -cf "${workdir}/layer.tar" -C "${workdir}/layer" models/config.json
+
+title="config.json"
+inlayer_path="/models/config.json"
+match_path="${inlayer_path#/}"
+if ! printf '%s\n' "${match_path}" | grep -Eq "${EXTRA_ARTIFACT_FILTER}" \
+  && ! printf '%s\n' "${title}" | grep -Eq "${EXTRA_ARTIFACT_FILTER}"; then
+  echo "FAIL: expected config.json to match EXTRA_ARTIFACT_FILTER" >&2
+  exit 1
+fi
+
+weight_title="model.safetensors"
+if printf '%s\n' "${weight_title}" | grep -Eq "${EXTRA_ARTIFACT_FILTER}"; then
+  echo "FAIL: safetensors must not match EXTRA_ARTIFACT_FILTER" >&2
+  exit 1
+fi
+
+tmp_dir="$(mktemp -d)"
+tar -xf "${workdir}/layer.tar" -C "${tmp_dir}"
+fetched_count=0
+while IFS= read -r -d '' extracted; do
+  rel_path="${extracted#"${tmp_dir}"/}"
+  rel_path="${rel_path#./}"
+  # Task image has GNU realpath -m; keep this check portable for macOS hosts.
+  if [[ "${rel_path}" == *".."* ]]; then
+    echo "FAIL: path escape: ${rel_path}" >&2
+    exit 1
+  fi
+  dest_path="${workdir}/source/${rel_path}"
+  mkdir -p "$(dirname "${dest_path}")"
+  cp -a "${extracted}" "${dest_path}"
+  fetched_count=$((fetched_count + 1))
+done < <(find "${tmp_dir}" -type f -print0)
+rm -rf "${tmp_dir}"
+
+if [[ "${fetched_count}" -ne 1 ]]; then
+  echo "FAIL: expected 1 extracted file, got ${fetched_count}" >&2
+  exit 1
+fi
+if [[ ! -f "${workdir}/source/models/config.json" ]]; then
+  echo "FAIL: missing ${workdir}/source/models/config.json" >&2
+  find "${workdir}/source" -print >&2 || true
+  exit 1
+fi
+grep -q '{"ok":true}' "${workdir}/source/models/config.json"
+
+echo "OK: container titled-layer extract self-check passed"

--- a/task/sast-snyk-check-oci-ta/0.5/tests/pre-apply-task-hook.sh
+++ b/task/sast-snyk-check-oci-ta/0.5/tests/pre-apply-task-hook.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
 echo "Removing computeResources for task: $1"
 yq -i eval '.spec.steps[].computeResources = {}' $1
 
@@ -14,3 +16,10 @@ echo "Creating snyk secret in namespace: $2"
 kubectl create secret generic snyk-secret \
     --from-literal=snyk_token="$SNYK_TOKEN" \
     --namespace="$2" || true
+
+echo "Creating fetch-extra-artifacts test ConfigMap in namespace: $2"
+kubectl create configmap snyk-fetch-extra-artifacts-test \
+    --from-file=check-container-layer-extract.sh="${SCRIPT_DIR}/check-container-layer-extract.sh" \
+    --from-file=fetch-extra-artifacts.sh="${SCRIPT_DIR}/../fetch-extra-artifacts.sh" \
+    --namespace="$2" \
+    --dry-run=client -o yaml | kubectl apply -f -

--- a/task/sast-snyk-check-oci-ta/0.5/tests/test-sast-snyk-check-oci-ta-container-layers.yaml
+++ b/task/sast-snyk-check-oci-ta/0.5/tests/test-sast-snyk-check-oci-ta-container-layers.yaml
@@ -1,0 +1,28 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-sast-snyk-check-oci-ta-container-layers
+spec:
+  description: |
+    Unit-test fetch-extra-artifacts titled-layer extract/filter/index-resolve
+    (the FETCH_EXTRA_ARTIFACTS=true container-image path). Does not call Snyk.
+  workspaces:
+    - name: tests-workspace
+  tasks:
+    - name: check-container-layer-extract
+      taskSpec:
+        volumes:
+          - name: tests
+            configMap:
+              name: snyk-fetch-extra-artifacts-test
+        steps:
+          - name: check
+            image: quay.io/konflux-ci/konflux-test:v1.5.6@sha256:365b172d2a8a145406f028d0a94a77b489fbdf9d84e5bd9529b1c3ad72f077b1
+            volumeMounts:
+              - name: tests
+                mountPath: /tests
+            script: |
+              #!/usr/bin/env bash
+              set -euo pipefail
+              bash /tests/check-container-layer-extract.sh

--- a/task/sast-snyk-check-oci-ta/0.5/tests/test-sast-snyk-check-oci-ta.yaml
+++ b/task/sast-snyk-check-oci-ta/0.5/tests/test-sast-snyk-check-oci-ta.yaml
@@ -6,8 +6,9 @@ metadata:
 spec:
   description: |
     Test for sast-snyk-check-oci-ta. FETCH_EXTRA_ARTIFACTS is false, so
-    fetch-extra-artifacts exits without fetching script-like OCI artifacts. The Snyk
-    scan still runs against trusted source from git-clone-oci-ta.
+    fetch-extra-artifacts exits without fetching OCI artifact blobs or titled
+    container layers. The Snyk scan still runs against trusted source from
+    git-clone-oci-ta.
   workspaces:
     - name: tests-workspace
   tasks:

--- a/task/sast-snyk-check-oci-ta/0.5/tests/test-sast-snyk-check-oci-ta.yaml
+++ b/task/sast-snyk-check-oci-ta/0.5/tests/test-sast-snyk-check-oci-ta.yaml
@@ -6,9 +6,9 @@ metadata:
 spec:
   description: |
     Test for sast-snyk-check-oci-ta. FETCH_EXTRA_ARTIFACTS is false, so
-    fetch-extra-artifacts exits without fetching OCI artifact blobs or titled
-    container layers. The Snyk scan still runs against trusted source from
-    git-clone-oci-ta.
+    fetch-extra-artifacts exits without fetching. Titled-layer extract is
+    covered by test-sast-snyk-check-oci-ta-container-layers. The Snyk scan
+    still runs against trusted source from git-clone-oci-ta.
   workspaces:
     - name: tests-workspace
   tasks:


### PR DESCRIPTION
## Summary
- Extend `FETCH_EXTRA_ARTIFACTS` so ModelCar/olot container images are no longer skipped: fetch and untar only titled layers matching `EXTRA_ARTIFACT_FILTER`.
- Resolve multi-arch indexes to linux/amd64 before extraction; keep the existing OCI-artifact blob path and default-off behavior unchanged.

## Test plan
- [x] `bash task/sast-snyk-check-oci-ta/0.5/tests/check-container-layer-extract.sh`
- [x] CI checks on this PR
- [ ] After merge/publish, enable in modelcar pipelines and bump the task digest