### PR TITLE
update(logging) - PSSECAUT-1604 - Adding csgrep of output file

### DIFF
--- a/task/sast-shell-check-oci-ta-min/0.1/sast-shell-check-oci-ta-min.yaml
+++ b/task/sast-shell-check-oci-ta-min/0.1/sast-shell-check-oci-ta-min.yaml
@@ -257,6 +257,7 @@ spec:
       echo "ShellCheck results have been saved to $OUTPUT_FILE"
 
       csgrep --mode=evtstat "$OUTPUT_FILE"
+      csgrep "$OUTPUT_FILE"
       csgrep --mode=sarif "$OUTPUT_FILE" >shellcheck-results.sarif
 
       TEST_OUTPUT=

--- a/task/sast-shell-check-oci-ta/0.1/sast-shell-check-oci-ta.yaml
+++ b/task/sast-shell-check-oci-ta/0.1/sast-shell-check-oci-ta.yaml
@@ -270,6 +270,7 @@ spec:
         echo "ShellCheck results have been saved to $OUTPUT_FILE"
 
         csgrep --mode=evtstat "$OUTPUT_FILE"
+        csgrep "$OUTPUT_FILE"
         csgrep --mode=sarif "$OUTPUT_FILE" >shellcheck-results.sarif
 
         TEST_OUTPUT=

--- a/task/sast-shell-check/0.1/sast-shell-check.yaml
+++ b/task/sast-shell-check/0.1/sast-shell-check.yaml
@@ -251,6 +251,7 @@ spec:
         echo "ShellCheck results have been saved to $OUTPUT_FILE"
 
         csgrep --mode=evtstat "$OUTPUT_FILE"
+        csgrep "$OUTPUT_FILE"
         csgrep --mode=sarif "$OUTPUT_FILE" > shellcheck-results.sarif
 
         TEST_OUTPUT=


### PR DESCRIPTION
- Adding csgrep of dynamically generated sarif file to shellcheck tasks. 
- This will increase logging output to stdout, which currently is not an issue in konflux
  - stdout logs are streamed to a google s3 bucket (cluster dependent)
  - While there are known reports of massive log line issues, this is primarily UI issues, and the struggle of the konflux UI to stream millions of log lines in the UI in real time
- Only the configuration provided is what is stored in etcd
  - This is ephemeral to the etcd 8 GB limit, once the pod is done the etcd files are moved to long term kube archive storage and are removed from the on cluster etcd limit. 
- By adding just this one line, we are barely increasing etcd footprint overall, leading to no additiona complications.  